### PR TITLE
Update monarch-specific.css

### DIFF
--- a/css/monarch-specific.css
+++ b/css/monarch-specific.css
@@ -182,6 +182,10 @@ figure {
     padding: 15px;
 }
 
+.panel-body {
+    overflow: hidden;
+}
+
 .right {
   float:right;
 }


### PR DESCRIPTION
Fixes the figure elements  (images and text) from overflowing their body panel container.
