### PR TITLE
Suggest making the info boxes resizable

### DIFF
--- a/widgets/phenogrid/js/phenogrid.js
+++ b/widgets/phenogrid/js/phenogrid.js
@@ -2671,7 +2671,7 @@ function modelDataPointPrint(point) {
 				height: 250,
 				maxHeight: 300,
 				minWidth: 400,
-				resizable: false,
+				resizable: true,
 				draggable: true,
 				dialogClass: "dialogBG",
 				position: { my: "top", at: "top+25%",of: "#svg_area"},


### PR DESCRIPTION
The FAQ info box contains a fair amount of text. It's hard to read this text with the fixed size of the box.
