### PR TITLE
Restore annotation sufficiency to phenotype tabs

### DIFF
--- a/css/monarch-common.css
+++ b/css/monarch-common.css
@@ -311,7 +311,12 @@ p {
 }
 /* Get a spinner for jQuery autocomplete wait. */
 .ui-autocomplete-loading {
+    background: white url('/image/waiting_ac.gif') right center no-repeat !important;
+}
+
+.ui-score-spinner {
     background: white url('/image/waiting_ac.gif') right center no-repeat;
+    padding-right: 15px;
 }
 
 .form-control {

--- a/js/monarch-common.js
+++ b/js/monarch-common.js
@@ -1,23 +1,13 @@
 /* This script document contains functions relating to general Monarch pages. */
 
-$(document).ready(function(){
-
-    /* Annotation Score Stars */
-
-    /* This displays the stars used to denote annotation sufficiency. For example,
-     * annotation sufficiency scores are currently located on the phenotype tab
-     * of the disease page. */
-    $.fn.stars = function() {
-        return this.each(function(i,e){$(e).html($('<span/>').width($(e).text()*16));});
-    };
-    $('.stars').stars();
+jQuery(document).ready(function(){
 
     /* This displays the help text about the annotation sufficiency score upon
      * hovering over the blue question mark box. */
-    $('#annotationscore > span.annotatequestion').hover(function() {
-        $('#annotationscore > span.annotatehelp').css({'display': 'block'});
+    jQuery('#annotationscore > span.annotatequestion').hover(function() {
+        jQuery('#annotationscore > span.annotatehelp').css({'display': 'block'});
     }, function() {
-        $('#annotationscore > span.annotatehelp').css({'display': 'none'});
+        jQuery('#annotationscore > span.annotatehelp').css({'display': 'none'});
     });
 
 
@@ -26,30 +16,92 @@ $(document).ready(function(){
     /* This displays the box of found terms upon hovering over a highlighted/linked
      * term. An example is located in the Text Annotater (found on the Annotate Text
      * tab of the main drop-down navigation menu). */
-    $('.linkedspan').hover(function() {
-        $(this).find('.linkedterms').css({'display': 'block'});
+    jQuery('.linkedspan').hover(function() {
+        jQuery(this).find('.linkedterms').css({'display': 'block'});
     }, function() {
-        $(this).find('.linkedterms').css({'display': 'none'});
+        jQuery(this).find('.linkedterms').css({'display': 'none'});
     });
 
 
     /* Show/Hide items */
     /* Used when a "more..." kind of functionality is desired */
-    $('.fewitems').click(function(event) {
-        $(this).hide();
-        $(this).parent().find('.moreitems').show();
-        $(this).parent().find('.hideitems').show();
+    jQuery('.fewitems').click(function(event) {
+        jQuery(this).hide();
+        jQuery(this).parent().find('.moreitems').show();
+        jQuery(this).parent().find('.hideitems').show();
     });
 
-    $('.hideitems').click(function(event) {
-        $(this).hide();
-        $(this).parent().find('.moreitems').hide();
-        $(this).parent().find('.hideitems').hide();
-        $(this).parent().find('.fewitems').show();
+    jQuery('.hideitems').click(function(event) {
+        jQuery(this).hide();
+        jQuery(this).parent().find('.moreitems').hide();
+        jQuery(this).parent().find('.hideitems').hide();
+        jQuery(this).parent().find('.fewitems').show();
     });
 
 
 });
+
+function getAnnotationScore() {
+    
+    var isLoading = false;
+    jQuery('#categories a[href="#phenotypes"]').click(function(event) {
+        if (isLoading == false){
+            isLoading = true;
+            getPhenotypesAndScore();
+        }
+    });
+    
+    function getPhenotypesAndScore(){
+        jQuery('.stars').hide();
+        var spinner_class = 'ui-score-spinner';
+        jQuery('.score-spinner').addClass(spinner_class);
+    
+        var id = this.location.pathname;
+        var slash_idx = id.indexOf('/');
+        id = id.substring(slash_idx+1);
+    
+        var query = '/' + id + '/phenotype_list.json';
+    
+        jQuery.ajax({
+            url : query,
+            dataType: "json",
+            error: function(){
+                console.log('ERROR: looking at: ' + query);
+            },
+            success: function(data) {
+            
+                var score_query = '/score';
+                var profile = JSON.stringify({features:data.phenotype_list});
+                var params = {'annotation_profile' : profile};
+                jQuery.ajax({
+                    type : 'POST',
+                    url : score_query,
+                    data : params,
+                    dataType: "json",
+                    error: function(){
+                        console.log('ERROR: looking at: ' + score_query);
+                    },
+                    success: function(data) {
+                        jQuery('.score-spinner').removeClass(spinner_class);
+                        console.log(data);
+                        var score = (5 * data.scaled_score);
+                        jQuery(".stars").text(score);
+                    
+                        /* This displays the stars used to denote annotation sufficiency. For example,
+                         * annotation sufficiency scores are currently located on the phenotype tab
+                         * of the disease page. */
+                        jQuery.fn.stars = function() {
+                            return this.each(function(i,e){jQuery(e).html(jQuery('<span/>').width(jQuery(e).text()*16));});
+                        };
+                        jQuery('.stars').stars();
+                        jQuery('.stars').show();
+                    }
+                });
+            }
+            
+        });
+    }    
+}
 
 function genTable(spec, rows) {
     var content = "";

--- a/lib/monarch/api.js
+++ b/lib/monarch/api.js
@@ -5905,6 +5905,12 @@ bbop.monarch.Engine.prototype.fetchClassInfo = function(id, opts) {
             
             var ontoGraph = new bbop.model.graph();
             ontoGraph.load_json(neighbors);
+            var children = ontoGraph.get_child_nodes(id, 'subClassOf');
+            if (typeof children  != 'undefined' && children.length == 0){
+                resultObj.isLeafNode = true;
+            } else {
+                resultObj.isLeafNode = false;
+            }
             // Iterating over edges to make triples
             // Maybe this is crazy and we should just have our upstream code
             // handle bbop graphs
@@ -7553,7 +7559,7 @@ bbop.monarch.Engine.prototype.fetchCoreDiseaseInfo = function(id) {
     var golrResponse = engine.fetchAssociations(id, 'subject_closure', filter, 10000);
     obj.phenotype_associations = golrResponse.documents();
     obj.phenotype_list = golrResponse.documents().map(function(doc){ 
-            return {"id" : doc.object, "label": doc.object_label, "observed": "positive"}
+            return {"id" : doc.object, "label": doc.object_label, "observed": "positive", "isPresent" : "true"}
     });
     
     return obj;
@@ -7588,7 +7594,7 @@ bbop.monarch.Engine.prototype.fetchCoreGeneInfo = function(id) {
     var golrResponse = engine.fetchAssociations(id, 'subject_closure', filter, 10000);
     obj.phenotype_associations = golrResponse.documents();
     obj.phenotype_list = golrResponse.documents().map(function(doc){ 
-            return {"id" : doc.object, "label": doc.object_label, "observed": "positive"}
+            return {"id" : doc.object, "label": doc.object_label, "observed": "positive", "isPresent" : "true"}
     });
     
     return obj;

--- a/lib/monarch/api.js
+++ b/lib/monarch/api.js
@@ -7629,5 +7629,6 @@ bbop.monarch.Engine.prototype.fetchDataInfo = function(id, opts) {
     } else {
         resultObj.database_cross_reference = [];
     }
+    resultObj.isLeafNode = true;
     return resultObj;
 }

--- a/lib/monarch/web/webapp.js
+++ b/lib/monarch/web/webapp.js
@@ -1558,7 +1558,7 @@ var fetchModelPage = function(request, id, fmt) {
         
         // Add templates
         info.includes.phenotype_anchor = addPhenotypeAnchor(info);
-        info.includes.phenotype_table = addPhenotypeTable();
+        info.includes.phenotype_table = addPhenotypeTable(info);
     
         // Add gene table
         info.includes.gene_anchor = addGeneAnchor(info);
@@ -1603,6 +1603,10 @@ var fetchModelPage = function(request, id, fmt) {
         info.hasXrefs = function() {return checkExistence(info.database_cross_reference)};
         info.hasPhenotypes = info.phenotypeNum;
         info.includes.phenogrid_anchor = Mustache.to_html(getTemplate('phenogrid-anchor'), info);
+        
+        //Launch function for annotation score
+        info.pup_tent_js_variables.push({name:'globalID',value:id});
+        info.monarch_launchable.push('getAnnotationScore(globalID)');
     
         var output = pup_tent.render('model.mustache', info,
                                      'monarch_base.mustache');
@@ -2195,7 +2199,6 @@ function mapStyleToCategories(style) {
     return categories;
 }
 
-
 var scoreFunction = function (request){
     engine.log("Ready to score");
     engine.log("Params:"+JSON.stringify(request.params));
@@ -2210,7 +2213,6 @@ var scoreFunction = function (request){
     var myresults = engine.getInformationProfile(annotation_profile,categories);
     return response.json(myresults);
 };
-
 
 app.get('/score', scoreFunction);
 app.post('/score', scoreFunction);
@@ -2275,7 +2277,6 @@ var simsearch = function(request, fmt) {
 };
 
 app.get('/simsearch/phenotype.:fmt?', simsearch);
-
 app.post('/simsearch/phenotype.:fmt?', simsearch);
 
 app.get('/annotate/text.:fmt?', function(request, fmt) {
@@ -3121,7 +3122,7 @@ app.get('/disease/:id.:fmt?',
             
             // Add templates
             info.includes.phenotype_anchor = addPhenotypeAnchor(info);
-            info.includes.phenotype_table = addPhenotypeTable();
+            info.includes.phenotype_table = addPhenotypeTable(info);
             
             // Add gene table
             info.includes.gene_anchor = addGeneAnchor(info);
@@ -3174,6 +3175,12 @@ app.get('/disease/:id.:fmt?',
             info.hasPhenotypes = info.phenotypeNum;
             info.includes.phenogrid_anchor = Mustache.to_html(getTemplate('phenogrid-anchor'), info);
             
+            //Launch function for annotation score
+            if (info.isLeafNode){
+                info.pup_tent_js_variables.push({name:'globalID',value:id});
+                info.monarch_launchable.push('getAnnotationScore(globalID)');
+            }
+            
             var output = pup_tent.render('disease.mustache', info,
                                          'monarch_base.mustache');
             return response.html(output);
@@ -3220,6 +3227,13 @@ var fetchFeatureSection = function(request, id, section, fmt) {
 
 var fetchFeaturePage = function(request, id, fmt) {
     try {
+        
+        //Curify ID if needed
+        if (/_/.test(id)){
+            engine.log("ID contains underscore, replacing with : and redirecting");
+            var newID = id.replace("_",":");
+            return response.redirect(genURL('gene',newID));
+        }
 
         // Rendering.
         var info = {};
@@ -3270,7 +3284,7 @@ var fetchFeaturePage = function(request, id, fmt) {
         
         // Add templates
         info.includes.phenotype_anchor = addPhenotypeAnchor(info);
-        info.includes.phenotype_table = addPhenotypeTable();
+        info.includes.phenotype_table = addPhenotypeTable(info);
         
         // Add gene table
         info.includes.disease_anchor = addDiseaseAnchor(info);
@@ -3322,6 +3336,10 @@ var fetchFeaturePage = function(request, id, fmt) {
         info.hasAka = function() {return checkExistence(info.synonyms)};
         info.hasXrefs = function() {return checkExistence(info.database_cross_reference)};
         info.hasPhenotypes = info.phenotypeNum;
+        
+        //Launch function for annotation score
+        info.pup_tent_js_variables.push({name:'globalID',value:id});
+        info.monarch_launchable.push('getAnnotationScore(globalID)');
         
         info.includes.phenogrid_anchor = Mustache.to_html(getTemplate('phenogrid-anchor'), info);
         
@@ -3379,7 +3397,7 @@ var fetchVariantPage = function(request, id, fmt) {
         
         // Add templates
         info.includes.phenotype_anchor = addPhenotypeAnchor(info);
-        info.includes.phenotype_table = addPhenotypeTable();
+        info.includes.phenotype_table = addPhenotypeTable(info);
         
         // Add gene table
         info.includes.disease_anchor = addDiseaseAnchor(info);
@@ -3425,6 +3443,11 @@ var fetchVariantPage = function(request, id, fmt) {
         info.hasXrefs = function() {return checkExistence(info.database_cross_reference)};
         
         info.includes.phenogrid_anchor = Mustache.to_html(getTemplate('phenogrid-anchor'), info);
+        
+        //Launch function for annotation score
+        info.pup_tent_js_variables.push({name:'globalID',value:id});
+        info.monarch_launchable.push('getAnnotationScore(globalID)');
+
         
         var output = pup_tent.render('variant.mustache', info,
                  'monarch_base.mustache');
@@ -3526,8 +3549,10 @@ function addPhenotypeAnchor(info) {
     return Mustache.to_html(getTemplate('anchor'), phenotype_anchor);
 }
 
-function addPhenotypeTable() {
-    var phenotype_table = {href: "phenotypes", div: "phenotypes-table"};
+function addPhenotypeTable(info) {
+    var phenotype_table = {href: "phenotypes", div: "phenotypes-table",
+                           isLeafNode: info.isLeafNode,
+                           isPhenotypeTable : true};
     return Mustache.to_html(getTemplate('golr-table'), phenotype_table);
 }
 

--- a/lib/monarch/web/webapp.js
+++ b/lib/monarch/web/webapp.js
@@ -2195,7 +2195,8 @@ function mapStyleToCategories(style) {
     return categories;
 }
 
-app.get('/score', function(request) {
+
+var scoreFunction = function (request){
     engine.log("Ready to score");
     engine.log("Params:"+JSON.stringify(request.params));
     var target = null;
@@ -2208,7 +2209,11 @@ app.get('/score', function(request) {
     annotation_profile = JSON.parse(annotation_profile);
     var myresults = engine.getInformationProfile(annotation_profile,categories);
     return response.json(myresults);
-});
+};
+
+
+app.get('/score', scoreFunction);
+app.post('/score', scoreFunction);
 
 
 // Method: simsearch

--- a/templates/golr-table.mustache
+++ b/templates/golr-table.mustache
@@ -1,5 +1,22 @@
 <div id="{{{href}}}" class="category">
   <div id="r3" class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
+    {{#isPhenotypeTable}}
+    {{#isLeafNode}}
+    <div id="annotationscore">
+      <span class="annotatetext">Annotation Sufficiency:</span>
+      <span class="score-spinner"></span>
+      <span class="stars"></span>
+      <span class="annotatequestion">?</span>
+      <span class="annotatehelp">
+           The annotation score reflects how the breadth and depth of
+           annotations for this disease compares to all of the other phenotypic
+           profiles in our corpus. A high score means that the disease is richly
+           annotated, both across a diverse set of phenotypic categories,
+           as well as in the number and specificity of each of the phenotypes.
+      </span>
+    </div>
+    {{/isLeafNode}}
+    {{/isPhenotypeTable}}
       
     <!-- Quiet rollover. -->
     <div class="panel panel-default">


### PR DESCRIPTION
- Restores annotation sufficiency score on phenotype tabs
- For disease pages this only runs on leaf nodes
- Fully client driven, only runs when clicking on the phenotype tab
