### PR TITLE
Home Page and Navbar fixes for https://github.com/monarch-initiative/monarch-app/issues/842

### DIFF
--- a/css/monarch-common.css
+++ b/css/monarch-common.css
@@ -13,6 +13,8 @@ p {
     clear: both;
 }
 
+
+
 /* Navbar */
 /* These are navbar styles that depend heavily on media queries to determine the
  * width of the user's browser window. Make sure that you are adding styles to the
@@ -20,6 +22,13 @@ p {
  *
  * The default Bootstrap behavior makes the navbar quite different from regular
  * browser width to smaller (e.g. smartphone browsers). */
+
+.navbar.monarch-navbar {
+    padding:0;
+    padding-left: 5px;
+    padding-right: 5px;
+    margin:0;
+}
 
 @media (min-width: 815px) {
     .monarch-navbar-container {
@@ -149,7 +158,6 @@ p {
     cursor: pointer;
 }
 
-
 /* Logos */
 /* These styles standardize the size of logos over all Monarch pages. */
 
@@ -266,40 +274,22 @@ p {
     text-align: center;
     font-weight: 200;
     font-size: 12px;
-    color: white;
-    transition: color 0.2s;
-    -webkit-transition: color 0.2s;
-    -moz-transition: color 0.2s;
-}
-#footer:hover {
     color: #777;
 }
-@media (min-width: 1110px) {
-    .wrapperforfooter {
-        min-height: 100%;
-        padding-bottom: 80px;
-    }
-    #footer {
-        margin-top: -80px;
-    }
+
+#footer.fadeable {
+    color: white;
+    transition: initial;
+    -webkit-transition: initial;
+    -moz-transition: initial;
 }
-@media (max-width: 1110px) {
-    .wrapperforfooter {
-        min-height: 100%;
-        padding-bottom: 90px;
-    }
-    #footer {
-        margin-top: -90px;
-    }
+
+#footer.fadeable:hover {
+    color: #777;
 }
-@media (max-width: 840px) {
-    .wrapperforfooter {
-        min-height: 100%;
-        padding-bottom: 110px;
-    }
-    #footer {
-        margin-top: -110px;
-    }
+
+.wrapperforfooter {
+    min-height: 100%;
 }
 
 /* Search Bar */
@@ -356,8 +346,18 @@ p {
  */
 
 .branding-logo {
-    max-height: 30px;
-    padding-bottom: 5px;
+    height: 30px;
+    width: 60px;
+    margin: 0;
+    margin-top: -3px;
+    margin-left: -5px;
+    margin-right: 4px;
+    padding: 0;
+}
+
+.navbar-brand {
+    font-size: 18px;
+    margin-top: -2px;
 }
 
 /* BS3 Pager from bbop.live_pager widget */
@@ -552,6 +552,7 @@ a:hover .hilite, a:active .hilite {
     width: auto;
 }
 .navbar { z-index: 100; } /* Default of 1000 interferes with popups etc. */
+.navbar { padding: 3px;}
 .page-header { text-align: center; }
 .page-header { text-align: center; }
 .page-header { text-align: center; }

--- a/css/monarch-home.css
+++ b/css/monarch-home.css
@@ -48,8 +48,17 @@
     max-height: 5em;
     width: auto;
     float: left;
-    padding-right: 1em;
+    margin-left: 0.3em;
+    margin-right: 2em;
+    margin-top: 0.3em;
+    margin-bottom: 2em;
 }
+
+.monarch-carousel-explore-title {
+    font-weight: 600;
+    font-size: 1.1em;
+}
+
 
 .monarch-nav-embedded-image {
     max-height: 1.5em;

--- a/js/HomePage.js
+++ b/js/HomePage.js
@@ -196,7 +196,7 @@ jQuery(document).ready(function(){
 
     // Ready search form in corner, with non-standard names.
     // (Default should not load as the default ids do not exists here.)
-    navbar_search_init('home_search', 'home_search_form');
+    //navbar_search_init('home_search', 'home_search_form');
 
     // Start carsousel.
     var mcid = '#' + "monarch-carousel"; // carousel series

--- a/lib/monarch/web/webapp.js
+++ b/lib/monarch/web/webapp.js
@@ -257,7 +257,12 @@ function staticTemplate(t) {
 function prepLandingPage() {
   // Rendering.
   var info = {};
-  addCoreRenderers(info);
+  var defaults = {
+      monarch_nav_search_p: true,
+      monarch_extra_footer_p: false,
+      monarch_footer_fade_p: false
+  };
+  addCoreRenderers(info, null, null, defaults);
   info.pup_tent_css_libraries.push("/monarch-landing.css");
   return info;
 }
@@ -273,6 +278,7 @@ function loadBlogData(category, lim) {
   return blog_res;
 }
 
+/*DELETEME
 function (loc,page,ctype) {
     var s = fs.read(loc+'/'+page);
     return {
@@ -281,13 +287,22 @@ function (loc,page,ctype) {
       status: 200
    };
 }
+*/
+
 
 // This function takes a json representation of some data
 // (for example, a disease and various associated genes, phenotypes)
 // intended to be rendered by some template (e.g. disease.mustache) and
 // adds additional functions or data to be used in the template.
-function addCoreRenderers(info, type, id){
-
+// The defaults arguments is used to supply initial values. For example, defaults might be:
+//   var defaults = {
+//       monarch_nav_search_p: false,
+//       monarch_extra_footer_p: true,
+//       monarch_footer_fade_p: false
+//   };
+//   addCoreRenderers(info, null, null, defaults);
+//
+function addCoreRenderers(info, type, id, defaults){
     // Initialize info
     if( ! info ){ info = {}; }
 
@@ -299,13 +314,26 @@ function addCoreRenderers(info, type, id){
     info.pup_tent_js_libraries = [];
     info.pup_tent_js_variables = [];
 
-    // Add default monarch layout controls.
     info.monarch_nav_search_p = true;
     info.monarch_extra_footer_p = false;
+    info.monarch_footer_fade_p = true;
+
+    // Apply defaults for monarch layout controls.
+    if (typeof defaults !== 'undefined') {
+        if (typeof(defaults.monarch_nav_search_p) !== 'undefined') {
+            info.monarch_nav_search_p = defaults.monarch_nav_search_p;
+        }
+        if (typeof(defaults.monarch_extra_footer_p) !== 'undefined') {
+            info.monarch_extra_footer_p = defaults.monarch_extra_footer_p;
+        }
+        if (typeof(defaults.monarch_footer_fade_p) !== 'undefined') {
+            info.monarch_footer_fade_p = defaults.monarch_footer_fade_p;
+        }
+    }
 
     // JS launcher.
     info.monarch_launchable = [];
-    
+
     // Other controls.
     info.alerts = [];
     info.scripts = [];
@@ -353,7 +381,7 @@ function addCoreRenderers(info, type, id){
         }
         // The concept of node is taken from the OWLAPI; a node
         // is a set of classes that are mutually equivalent
-        var node = equivalentClasses.map(function(c){return c.id}).concat(id);
+        var node = equivalentClasses.map(function(c){return c.id;}).concat(id);
 
         for (var k in info.relationships) {
             var rel = info.relationships[k];
@@ -371,16 +399,16 @@ function addCoreRenderers(info, type, id){
                 }
             }
         }
-        info.superClasses = superClasses.map(function(c){return genObjectHref(type,c)});
-        info.subClasses = subClasses.map(function(c){return genObjectHref(type,c)});
-        info.equivalentClasses = equivalentClasses.map(function(c){return genObjectHref(type,c)+" ("+c.id+")"});
+        info.superClasses = superClasses.map(function(c){return genObjectHref(type,c);});
+        info.subClasses = subClasses.map(function(c){return genObjectHref(type,c);});
+        info.equivalentClasses = equivalentClasses.map(function(c){return genObjectHref(type,c)+" ("+c.id+")";});
     }
     info.includes = {};
     var alys_id = engine.config.analytics_id || null;
     info.includes.analytics = Mustache.to_html(getTemplate('analytics'),
                            {'analytics_id': alys_id});
-    info.includes.navbar = Mustache.to_html(getTemplate('navbar'), {});
-    info.includes.footer = Mustache.to_html(getTemplate('footer'), {});
+    info.includes.navbar = Mustache.to_html(getTemplate('navbar'), info);
+    info.includes.footer = Mustache.to_html(getTemplate('footer'), info);
     info.includes.classificationComponent = Mustache.to_html(getTemplate('classificationComponent'), info);
 
     info.isProduction = engine.config.type == 'production';
@@ -2874,11 +2902,14 @@ app.get('/', function(request, page){
 
     // Rendering.
     var info = {};
-    addCoreRenderers(info);
-    
-    // Overrides to addCoreRenderers().
-    info.monarch_nav_search_p = false;
-    info.monarch_extra_footer_p = true;
+
+    var defaults = {
+        monarch_nav_search_p: true,
+        monarch_extra_footer_p: true,
+        monarch_footer_fade_p: false
+    };
+
+    addCoreRenderers(info, null, null, defaults);
 
     // Now add the stuff that we need to move forward.
     //info.pup_tent_css_libraries.push("/bootstrap-glyphicons.css");
@@ -2904,11 +2935,13 @@ app.get('/labs/scratch-homepage', function(request, page){
 
     // Rendering.
     var info = {};
-    addCoreRenderers(info);
-    
-    // Overrides to addCoreRenderers().
-    info.monarch_nav_search_p = false;
-    info.monarch_extra_footer_p = true;
+
+    var defaults = {
+        monarch_nav_search_p: false,
+        monarch_extra_footer_p: true,
+        monarch_footer_fade_p: false
+    };
+    addCoreRenderers(info, null, null, defaults);
 
     // Now add the stuff that we need to move forward.
     //info.pup_tent_css_libraries.push("/bootstrap-glyphicons.css");

--- a/start-server-dev.sh
+++ b/start-server-dev.sh
@@ -1,4 +1,3 @@
 #!/bin/sh
 
-./update_dependencies.sh
 ./start-server.sh dev

--- a/templates/disease_main.mustache
+++ b/templates/disease_main.mustache
@@ -78,18 +78,8 @@
 </div>
 
 <!-- Footer. -->
-<hr>
-<footer>
-  <!-- <div id="footer"> -->
-  <div style="padding: 10px 40px 10px; text-align: center; font-weight: 200; font-size: 12px;">
-    The Monarch Initiative is a collaboration between Oregon Health & Science University,
-    University of California, San Diego, Lawrence Berkeley National Laboratory, the University of
-    Pittsburgh, Sanger Institute, and Charité - Universitätsmedizin Berlin
-    and is supported generously by a NIH Office of the Director Grant #5R24OD011883.
-    <br />
-    Except where otherwise noted, this work is licensed under a Creative Commons <a href="https://creativecommons.org/licenses/by/3.0/us/">Attribution 3.0</a> License.
-  </div>
-</footer>
+<hr/>
+{{{includes.footer}}}
  
 </body>
 </html>

--- a/templates/footer.mustache
+++ b/templates/footer.mustache
@@ -1,8 +1,22 @@
-<div id="footer">
-    Except where otherwise noted, this work is licensed under a Creative Commons Attribution
-    3.0 License.<br/>
+<footer id="footer"
+    {{#monarch_footer_fade_p}}
+    class="fadeable"
+    {{/monarch_footer_fade_p}}>
     The Monarch Initiative is a collaboration between Oregon Health & Science University,
     University of California, San Diego, Lawrence Berkeley National Laboratory, the University of
     Pittsburgh, Sanger Institute, and Charité - Universitätsmedizin Berlin
-    and is supported generously by a NIH Office of the Director Grant #5R24OD011883.
-</div>
+    and is supported generously by a NIH Office of the Director Grant #5R24OD011883.<br/>
+    Except where otherwise noted, this work is licensed under a Creative Commons Attribution
+    3.0 License.
+    {{#monarch_extra_footer_p}}
+        Banner image distributed under the <a href="https://creativecommons.org/licenses/by-sa/3.0/deed.en">CC-BY-SA
+        3.0</a>, composed of images distributed under the <a
+            href="https://creativecommons.org/licenses/by-sa/3.0/deed.en">CC-BY-SA 3.0</a> by
+        <a href="https://commons.wikimedia.org/wiki/File:GinkgoLeaves.jpg">Joe Schneid</a>,
+        <a href="https://commons.wikimedia.org/wiki/File:High_School_Biology_Cover.jpg">CK-12 Foundation</a>,
+        <a href="https://commons.wikimedia.org/wiki/File:White_flowers_b.jpg">Alvesgaspar</a>,
+        <a href="https://commons.wikimedia.org/wiki/File:Astrocyte5.jpg">GerryShaw</a>, and
+        <a href="https://commons.wikimedia.org/wiki/File:Ovamat4wb.jpg">Leo van der Ven</a>; all other under public
+        domain.
+    {{/monarch_extra_footer_p}}
+</footer>

--- a/templates/gene_main.mustache
+++ b/templates/gene_main.mustache
@@ -109,18 +109,8 @@
 </div></div>
 
 <!-- Footer. -->
-<hr>
-<footer>
-  <!-- <div id="footer"> -->
-  <div style="padding: 10px 40px 10px; text-align: center; font-weight: 200; font-size: 12px;">
-    The Monarch Initiative is a collaboration between Oregon Health & Science University,
-    University of California, San Diego, Lawrence Berkeley National Laboratory, the University of
-    Pittsburgh, Sanger Institute, and Charité - Universitätsmedizin Berlin
-    and is supported generously by a NIH Office of the Director Grant #5R24OD011883.
-    <br />
-    Except where otherwise noted, this work is licensed under a Creative Commons <a href="https://creativecommons.org/licenses/by/3.0/us/">Attribution 3.0</a> License.
-  </div>
-</footer>
-  
+<hr/>
+{{{includes.footer}}}
+
 </body>
 </html>

--- a/templates/home-page.mustache
+++ b/templates/home-page.mustache
@@ -240,9 +240,9 @@ window.twttr = (function(d, s, id) {
 	      Find models and phenotypes similar to a set of abnormal phenotypes of interest and then visualize their overlap.
 	    </p>
 	    <div class="center-block text-center">
-	      <button class="btn btn-primary center-block" href="/analyze/phenotypes">
+	      <a class="btn btn-primary center-block" href="/analyze/phenotypes">
 			Go to Phenotype Profile Analysis &raquo;
-	      </button>
+	      </a>
 	    </div>
 	  </div>
 	</div>

--- a/templates/home-page.mustache
+++ b/templates/home-page.mustache
@@ -23,51 +23,58 @@
 	<div class="panel-body">
 
 	  <div id="monarch-carousel" class="monarch-carousel">
+
 	    <div class="monarch-carousel-item monarch-carousel-item-selected">
-	      <p>
-		<img src="/image/carousel-diseases-0.5.jpg" class="monarch-carousel-embedded-image" alt="Diseases" />
-		<strong>Learn about Mendelian diseases</strong><br />
+			<a role="button" href="/disease">
+				<img src="/image/carousel-diseases-0.5.jpg" class="monarch-carousel-embedded-image" alt="Diseases" />
+				<span class="monarch-carousel-explore-title">Learn about Mendelian diseases &raquo;</span>
+			</a>
+			<br />
       		Diseases described by collections of phenotypes can be
       		compared to each other and to animal models to
       		investigate genetic underpinnings.
-		<a class="btn btn-primary btn-mini" role="button" href="/disease">More &raquo;</a>
-	      </p>
 	    </div>
+
 	    <div class="monarch-carousel-item monarch-carousel-item-unselected">
-	      <p>
-		<img src="/image/carousel-phenotypes-0.5.jpg" class="monarch-carousel-embedded-image" alt="Phenotypes" />
-      		<strong>Explore phenotypes</strong><br /> Similar
+				<a role="button" href="/phenotype">
+					<img src="/image/carousel-phenotypes-0.5.jpg" class="monarch-carousel-embedded-image" alt="Phenotypes" />
+					<span class="monarch-carousel-explore-title">Explore phenotypes &raquo;</span>
+				</a>
+      	<br />
+      		Similar
       		phenotypes may be observed in various diseases and
       		across species.
-		<a class="btn btn-primary btn-mini" role="button" href="/phenotype">More &raquo;</a>
-	      </p>
+					&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
 	    </div>
+
 	    <div class="monarch-carousel-item monarch-carousel-item-unselected monarch-carousel-item-largest">
-	      <p>
-		<img src="/image/carousel-models-0.5.jpg" class="monarch-carousel-embedded-image" alt="Models" />
-      		<strong>Find models of disease</strong><br /> In vitro
-      		and in vivo disease models can recapitulate some or
-      		all phenotypes of human disease.  Comparison of animal
-      		model phenotypes with human disease can suggest
-      		candidate genes.
-		<a class="btn btn-primary btn-mini" role="button" href="/model">More &raquo;</a>
-	      </p>
+				<a role="button" href="/model">
+					<img src="/image/carousel-models-0.5.jpg" class="monarch-carousel-embedded-image" alt="Models" />
+					<span class="monarch-carousel-explore-title">Find models of disease &raquo;</span>
+				</a>
+    		<br/>
+    		In vitro
+    		and in vivo disease models can recapitulate some or
+    		all phenotypes of human disease.  Comparison of animal
+    		model phenotypes with human disease can suggest
+    		candidate genes.
 	    </div>
+
 	    <div class="monarch-carousel-item monarch-carousel-item-unselected">
-	      <p>
-		<img src="/image/carousel-genes-0.5.jpg" class="monarch-carousel-embedded-image" alt="Genes" />
-      		<strong>Understand the genetics</strong><br />
+				<a role="button" href="/gene">
+					<img src="/image/carousel-genes-0.5.jpg" class="monarch-carousel-embedded-image" alt="Genes" />
+					<span class="monarch-carousel-explore-title">Understand the genetics &raquo;</span>
+				</a>
+ 				<br />
       		Variations in genes and other genomic features are
       		often associated with diseases and variant phenotypes.
       		Learn about the phenotypes associated with your
       		favorite gene.
-		<a class="btn btn-primary btn-mini" role="button" href="/gene">More &raquo;</a>
-	      </p>
 	    </div>
 	  </div>
 
 	  <!-- The weird tabber thing. -->
-	  <div class="clearfix"></div>
+	  <div style="clear:both;"></div>
 	  <div id="monarch-tabber" class="container monarch-tabber">
 	    <div class="row monarch-tabber-controls">
 	      <div class="col-xs-12 col-sm-6 col-md-6 col-lg-3 monarch-tabber-control">
@@ -157,14 +164,41 @@
 
 	</div>
 	<div id="twitter" class="col-xs-12 col-sm-6 col-md-6 col-lg-6">
+	    <a  class="twitter-timeline"
+	    	href="https://twitter.com/search?q=%40MonarchInit+OR+%23raredisease+OR+%40GA4GH+OR+%40phenomecentral"
+	    	data-widget-id="527567015918051328"
+	    	data-chrome=""
+	    	height="340"
+	    	width="520">
+	    	Loading Tweets about "@MonarchInit OR #raredisease OR @GA4GH OR @phenomecentral"
+	    </a>
 
-	  <p>
-	    <a class="twitter-timeline" href="https://twitter.com/search?q=%40MonarchInit+OR+%23raredisease+OR+%40GA4GH+OR+%40phenomecentral" data-widget-id="527567015918051328">Tweets about "@MonarchInit OR #raredisease OR @GA4GH OR @phenomecentral"</a>
+<script>
+// From https://dev.twitter.com/web/javascript/loading - 7/26/2015
+
+window.twttr = (function(d, s, id) {
+  var js, fjs = d.getElementsByTagName(s)[0],
+    t = window.twttr || {};
+  if (d.getElementById(id)) return t;
+  js = d.createElement(s);
+  js.id = id;
+  js.src = "https://platform.twitter.com/widgets.js";
+  fjs.parentNode.insertBefore(js, fjs);
+
+  t._e = [];
+  t.ready = function(f) {
+    t._e.push(f);
+  };
+
+  return t;
+}(document, "script", "twitter-wjs"));
+</script>
+
+<!--
 	    <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
-	  </p>
-
+-->
+	  </div>
 	</div>
-      </div>
 
     </div>
 
@@ -175,15 +209,10 @@
       <div>
 	<div class="panel panel-default"> <!-- style="padding-bottom: 0;"> -->
 	  <div class="panel-heading">
-	    <h3 class="panel-title">Search Monarch Data</h3>
+	    <h3 class="panel-title">Advanced Phenotype Search</h3>
 	  </div>
 	  <div class="panel-body">
-
-	    <!-- <p> -->
-	    <!--   Search Monarch data. -->
-	    <!-- </p> -->
-	    <!-- class="navbar-form" -->
-
+<!--
 	    <h5><strong>Basic Search</strong></h5>
 	    <p>
 	      Select from autocomplete and jump to relevant pages.
@@ -192,73 +221,32 @@
 	      <form id="home_search_form"
 		    action="/search"
 		    role="form">
-		
-		<div class="input-group">
-		  
-		  <input id="home_search"
-			 type="text"
-			 class="form-control"
-			 placeholder="Search (e.g. Parkinson's)" />
-		  <span class="input-group-btn">
-                    <button class="btn btn-primary" type="submit">Go</button>
-		  </span>
-		</div>
 
-		<!-- <select class="form-control"> -->
-		<!--   <option>1</option> -->
-		<!--   <option>2</option> -->
-		<!--   <option>3</option> -->
-		<!--   <option>4</option> -->
-		<!--   <option>5</option> -->
-		<!-- </select> -->
-		
-		<!-- <div class="panel panel-default" style="padding-bottom: 0;"> -->
-		<!--   <div class="panel-heading" style="margin-bottom: 0;"> -->
-		<!--     <span><small><a data-toggle="collapse" data-target="#collapseOne" aria-expanded="true" aria-controls="collapseOne">Advanced options</a></small></span> -->
-		<!--   </div> -->
-		<!--   <div id="collapseOne" class="panel-collapse collapse"> -->
-		<!--     <div class="panel-body"> -->
-		
-		<!--       <div class="radio"> -->
-		<!-- 	<label> -->
-		<!-- 	  <input type="radio" name="optionsRadios" id="optionsRadios1" value="option1" checked> -->
-		<!-- 	  Option one -->
-		<!-- 	</label> -->
-		<!--       </div> -->
-		<!--       <div class="radio"> -->
-		<!-- 	<label> -->
-		<!-- 	  <input type="radio" name="optionsRadios" id="optionsRadios2" value="option2"> -->
-		<!-- 	  Option two -->
-		<!-- 	</label> -->
-		<!--       </div> -->
-		<!--       <div class="radio disabled"> -->
-		<!-- 	<label> -->
-		<!-- 	  <input type="radio" name="optionsRadios" id="optionsRadios3" value="option3" disabled> -->
-		<!-- 	  Option three -->
-		<!-- 	</label> -->
-		<!--       </div> -->
-		
-		<!--     </div> -->
-		<!--   </div> -->
-		<!-- </div> -->
+			<div class="input-group">
 
+			<input id="home_search"
+				type="text"
+				class="form-control"
+				placeholder="Search (e.g. Parkinson's)" />
+				<span class="input-group-btn">
+				    <button class="btn btn-primary" type="submit">Go</button>
+				</span>
+			</div>
 	      </form>
 	    </p>
+-->
 
-	    <h5><strong>Advanced Phenotype Search</strong></h5>
 	    <p class="">
-	      Find models and phenotypes similar to a set of
-	      abnormal phenotypes of interest.
+	      Find models and phenotypes similar to a set of abnormal phenotypes of interest and then visualize their overlap.
 	    </p>
-	    <p class="">
-	      <a class="btn btn-primary" href="/analyze/phenotypes">
-		Go to Advanced Search &raquo;
-	      </a>
-	    </p>	    
-
+	    <div class="center-block text-center">
+	      <button class="btn btn-primary center-block" href="/analyze/phenotypes">
+			Go to Phenotype Profile Analysis &raquo;
+	      </button>
+	    </div>
 	  </div>
 	</div>
-      </div>
+	</div>
 
       <!-- Placeholder. -->
       <div class="row">

--- a/templates/labs/blog-scratch-base.mustache
+++ b/templates/labs/blog-scratch-base.mustache
@@ -125,19 +125,9 @@
     <!-- And all between. -->
     {{&pup_tent_content}}
 
-    <!-- Footer. -->
-    <hr>
-    <footer>
-      <!-- <div id="footer"> -->
-      <div style="padding: 10px 40px 10px; text-align: center; font-weight: 200; font-size: 12px;">
-	Except where otherwise noted, this work is licensed under a Creative Commons Attribution
-	3.0 License.<br/>
-	The Monarch Initiative is a collaboration between Oregon Health & Science University,
-	University of California, San Diego, Lawrence Berkeley National Laboratory, the University of
-	Pittsburgh, Sanger Institute, and Charité - Universitätsmedizin Berlin
-	and is supported generously by a NIH Office of the Director Grant #5R24OD011883.
-      </div>
-    </footer>
+	<!-- Footer. -->
+	<hr/>
+	{{{includes.footer}}}
 
   </body>
 </html>

--- a/templates/labs/blog-scratch-nav.mustache
+++ b/templates/labs/blog-scratch-nav.mustache
@@ -1,5 +1,5 @@
 <div class="navbar navbar-inverse navbar-fixed-top" role="navigation">
-  <div class="containter-fluid"> <!-- monarch-navbar-container">-->
+  <div class="container-fluid"> <!-- monarch-navbar-container">-->
     <div class="navbar-header">
       <button type="button" class="navbar-toggle" data-toggle="collapse"
               data-target="#collapsed-navbar">

--- a/templates/model_main.mustache
+++ b/templates/model_main.mustache
@@ -75,18 +75,8 @@
 </div>
 
 <!-- Footer. -->
-<hr>
-<footer>
-  <!-- <div id="footer"> -->
-  <div style="padding: 10px 40px 10px; text-align: center; font-weight: 200; font-size: 12px;">
-    The Monarch Initiative is a collaboration between Oregon Health & Science University,
-    University of California, San Diego, Lawrence Berkeley National Laboratory, the University of
-    Pittsburgh, Sanger Institute, and Charité - Universitätsmedizin Berlin
-    and is supported generously by a NIH Office of the Director Grant #5R24OD011883.
-    <br />
-    Except where otherwise noted, this work is licensed under a Creative Commons <a href="https://creativecommons.org/licenses/by/3.0/us/">Attribution 3.0</a> License.
-  </div>
-</footer>
+<hr/>
+{{{includes.footer}}}
 
 </body>
 </html>

--- a/templates/monarch-base-bs3.mustache
+++ b/templates/monarch-base-bs3.mustache
@@ -36,136 +36,17 @@
 <body style="padding-top: 40px;">
 
 <!-- Nav. -->
-<div class="navbar navbar-inverse navbar-fixed-top" role="navigation">
-    <div class="container-fluid"> <!-- monarch-navbar-container">-->
-        <div class="navbar-header">
-            <button type="button" class="navbar-toggle" data-toggle="collapse"
-                    data-target="#collapsed-navbar">
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-            </button>
-            <a class="navbar-brand" href="/">
-                <img class="branding-logo"
-                     src="/image/logo.png"
-                     alt="Monarch Initiative logo"
-                     title="Monarch Initiative front page">
-                Monarch
-            </a>
-        </div>
-        <div id="collapsed-navbar" class="nav-collapse collapse">
-            <ul class="nav navbar-nav">
-                <li class="dropdown">
-                    <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                        <i class="icon-th-large"></i>Browse <b class="caret"></b></a>
-                    <ul class="dropdown-menu">
-                        <li><a href="/disease/">Diseases</a></li>
-                        <li><a href="/phenotype/">Phenotypes</a></li>
-                        <li><a href="/gene/">Genes</a></li>
-                        <li><a href="/model/">Models</a></li>
-                        <!-- <li><a href="/literature/">Literature</a></li> -->
-                    </ul>
-                </li>
-                <li class="dropdown">
-                    <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                        <i class="icon-th-large"></i>Analyze <b class="caret"></b></a>
-                    <ul class="dropdown-menu">
-                        <li><a href="/analyze/phenotypes/">Phenotypes</a></li>
-                        <li><a href="/annotate/text">Annotate Text</a></li>
-                        <li><a href="/page/exomes/">Exomes</a></li>
-                    </ul>
-                </li>
-                <li class="dropdown">
-                    <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                        <i class="icon-th-large"></i>About <b class="caret"></b></a>
-                    <ul class="dropdown-menu">
-                        <li><a href="/page/about">About Monarch</a></li>
-                        <li><a href="/sources">Data Sources</a></li>
-                        <li><a href="/page/releases">Releases</a></li>
-                        <li><a href="/page/team">Monarch Team</a></li>
 
-                    </ul>
-                </li>
-                <li class="dropdown">
-                    <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                        <i class="icon-th-large"></i>Documentation <b class="caret"></b></a>
-                    <ul class="dropdown-menu">
-                        <li><a href="/page/software">Monarch Software</a></li>
-                        <li><a href="/page/services">Monarch RESTful API</a></li>
-                        <li><a href="/docs/index.html">Javascript API</a></li>
-                        <li><a href="/page/phenogrid">Monarch Phenotype Grid Widget</a></li>
-                        <li>
-                            <a href="http://monarch-initiative.blogspot.com/2015/01/how-to-annotate-patients-phenotypic.html">Phenotype
-                                Curation Guidelines</a></li>
-                        <li><a href="https://github.com/monarch-initiative/monarch-app">GitHub Project</a></li>
-                        <li><a href="https://code.google.com/p/phenotype-ontologies/">Ontologies</a></li>
-                        <li><a href="/page/pubs">Publications</a></li>
-                        <li><a href="/page/glossary">Glossary</a></li>
-                    </ul>
-                </li>
-                <li class="dropdown">
-                    <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                        <i class="icon-th-large"></i>Contact <b class="caret"></b></a>
-                    <ul class="dropdown-menu">
-                        <li><a href="https://github.com/monarch-initiative/monarch-app/issues">Issue Tracker</a></li>
-                        <li><a href="mailto:info@monarchinitiative.org">Email Us</a></li>
-                        <li><a href="http://mail.monarchinitiative.org/mailman/listinfo/users">Join Listserve</a></li>
-                    </ul>
-                </li>
-            </ul>
-
-            {{#monarch_nav_search_p}}
-                <ul class="nav navbar-nav navbar-right searchspace">
-                    <li>
-                        <form id="search_form"
-                              class="navbar-form"
-                              action="/search"
-                              role="search">
-                            <div class="form-group">
-                                <input id="search"
-                                       type="text"
-                                       class="form-control"
-                                       placeholder="Search (e.g. Parkinson's)"/>
-                            </div>
-                        </form>
-                    </li>
-                </ul>
-            {{/monarch_nav_search_p}}
-
-        </div>
-    </div>
-</div>
+{{{includes.navbar}}}
 
 <!-- And all between. -->
+<div class="wrapperforfooter">
 {{&pup_tent_content}}
+</div>
 
 <!-- Footer. -->
-<hr>
-<footer>
-    <!-- <div id="footer"> -->
-    <div style="padding: 10px 40px 10px; text-align: center; font-weight: 200; font-size: 12px;">
-        The Monarch Initiative is a collaboration between Oregon Health & Science University,
-        University of California, San Diego, Lawrence Berkeley National Laboratory, the University of
-        Pittsburgh, Sanger Institute, and Charité - Universitätsmedizin Berlin
-        and is supported generously by a NIH Office of the Director Grant #5R24OD011883.
-        <br/>
-        Except where otherwise noted, this work is licensed under a Creative Commons <a
-            href="https://creativecommons.org/licenses/by/3.0/us/">Attribution 3.0</a> License.
-        {{#monarch_extra_footer_p}}
-            <!-- Splash info. -->
-            Banner image distributed under the <a href="https://creativecommons.org/licenses/by-sa/3.0/deed.en">CC-BY-SA
-            3.0</a>, composed of images distributed under the <a
-                href="https://creativecommons.org/licenses/by-sa/3.0/deed.en">CC-BY-SA 3.0</a> by
-            <a href="https://commons.wikimedia.org/wiki/File:GinkgoLeaves.jpg">Joe Schneid</a>,
-            <a href="https://commons.wikimedia.org/wiki/File:High_School_Biology_Cover.jpg">CK-12 Foundation</a>,
-            <a href="https://commons.wikimedia.org/wiki/File:White_flowers_b.jpg">Alvesgaspar</a>,
-            <a href="https://commons.wikimedia.org/wiki/File:Astrocyte5.jpg">GerryShaw</a>, and
-            <a href="https://commons.wikimedia.org/wiki/File:Ovamat4wb.jpg">Leo van der Ven</a>; all other under public
-            domain.
-            <!-- Done splash -->
-        {{/monarch_extra_footer_p}}
-    </div>
-</footer>
+<hr/>
+{{{includes.footer}}}
 
 </body>
 </html>

--- a/templates/navbar.mustache
+++ b/templates/navbar.mustache
@@ -1,13 +1,19 @@
-<div class="navbar navbar-inverse navbar-fixed-top" role="navigation">
-    <div class="containter-fluid"> <!-- monarch-navbar-container">-->
+<div class="navbar navbar-inverse navbar-fixed-top monarch-navbar" role="navigation">
+    <div class="container-fluid">
         <div class="navbar-header">
             <button type="button" class="navbar-toggle" data-toggle="collapse"
-                data-target="#collapsed-navbar">
+                    data-target="#collapsed-navbar">
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a class="navbar-brand" href="/">Monarch</a>
+            <a class="navbar-brand" href="/">
+                <img class="branding-logo"
+                     src="/image/logo.png"
+                     alt="Monarch Initiative logo"
+                     title="Monarch Initiative front page">
+                Monarch
+            </a>
         </div>
         <div id="collapsed-navbar" class="nav-collapse collapse">
             <ul class="nav navbar-nav">
@@ -39,6 +45,7 @@
                         <li><a href="/sources">Data Sources</a></li>
                         <li><a href="/page/releases">Releases</a></li>
                         <li><a href="/page/team">Monarch Team</a></li>
+
                     </ul>
                 </li>
                 <li class="dropdown">
@@ -50,8 +57,7 @@
                         <li><a href="/docs/index.html">Javascript API</a></li>
                         <li><a href="/page/phenogrid">Monarch Phenotype Grid Widget</a></li>
                         <li><a href="http://monarch-initiative.blogspot.com/2015/01/how-to-annotate-patients-phenotypic.html">Phenotype Curation Guidelines</a></li>
-                        <li><a href="https://github.com/monarch-initiative/monarch-app">GitHub
-                        Project</a></li>
+                        <li><a href="https://github.com/monarch-initiative/monarch-app">GitHub Project</a></li>
                         <li><a href="https://code.google.com/p/phenotype-ontologies/">Ontologies</a></li>
                         <li><a href="/page/pubs">Publications</a></li>
                         <li><a href="/page/glossary">Glossary</a></li>
@@ -67,7 +73,8 @@
                     </ul>
                 </li>
             </ul>
-            <form id="search_form" class="navbar-form navbar-left searchspace" action="/search" role="search">
+            {{#monarch_nav_search_p}}
+            <form id="search_form" class="navbar-form navbar-right searchspace" action="/search" role="search">
                 <div class="input-group">
                 <input id="search" type="text" class="form-control search-box" placeholder="Search (e.g. Parkinson's)"/>
                 <span class="input-group-btn nav-search-btn">
@@ -75,6 +82,7 @@
                 </span>
                 </div>
             </form>
+            {{/monarch_nav_search_p}}
         </div>
     </div>
 </div>

--- a/templates/phenotype_main.mustache
+++ b/templates/phenotype_main.mustache
@@ -79,18 +79,8 @@
 </div>
 
 <!-- Footer. -->
-<hr>
-<footer>
-  <!-- <div id="footer"> -->
-  <div style="padding: 10px 40px 10px; text-align: center; font-weight: 200; font-size: 12px;">
-    The Monarch Initiative is a collaboration between Oregon Health & Science University,
-    University of California, San Diego, Lawrence Berkeley National Laboratory, the University of
-    Pittsburgh, Sanger Institute, and Charité - Universitätsmedizin Berlin
-    and is supported generously by a NIH Office of the Director Grant #5R24OD011883.
-    <br />
-    Except where otherwise noted, this work is licensed under a Creative Commons <a href="https://creativecommons.org/licenses/by/3.0/us/">Attribution 3.0</a> License.
-  </div>
-</footer>
+<hr/>
+{{{includes.footer}}}
   
 </body>
 </html>

--- a/tests/behave/README.org
+++ b/tests/behave/README.org
@@ -52,3 +52,13 @@
   Or against the UI/server target of your choice:
 
   : TARGET=http://localhost:8989 behave
+
+* Debugging tests
+
+It is sometimes useful to pause the tests so that you can see what Selenium sees. This can
+be accomplished with Python's 'time.sleep' function:
+
+  : import time
+    ...
+  : time.sleep(5)  # 5 seconds
+

--- a/tests/behave/maui_autocomplete.feature
+++ b/tests/behave/maui_autocomplete.feature
@@ -6,26 +6,26 @@ Feature: Basic autocomplete works
  ## No Background necessary.
 
  @ui
- Scenario: "food" in the home search with submit goes to a search page
+ Scenario: "food" in the navbar search with submit goes to a search page
     Given I go to page "/"
-     and I type "food" into the home search
-     and I submit home search
+     and I type "food" into the navbar search
+     and I submit navbar search
      then the title should be "Search Results: food"
      and the document should contain "food allergy"
      and the document should contain "botulism"
 
  @ui
- Scenario: "food" in the home search with a click goes to a details page
+ Scenario: "food" in the navbar search with a click goes to a details page
     Given I go to page "/"
-     and I type "food" into the home search
+     and I type "food" into the navbar search
      and I wait until "food allergy" appears in the autocomplete 
      and I click the autocomplete item "food allergy"
      then the title should be "Monarch Disease: food allergy (DOID:3044)"
 
  @ui
- Scenario: "ZRS" in the home search with a click goes to a gene page
+ Scenario: "ZRS" in the navbar search with a click goes to a gene page
     Given I go to page "/"
-     and I type "ZRS" into the home search
+     and I type "ZRS" into the navbar search
      and I wait until "ZRS" appears in the autocomplete 
      and I click the autocomplete item "ZRS"
      then the title should be "Monarch Gene: LMBR1 (NCBIGene:64327)"

--- a/tests/behave/maui_gene.feature
+++ b/tests/behave/maui_gene.feature
@@ -1,9 +1,9 @@
 Feature: Gene page description
  The page displays the text-based gene description as expected
- 
+
  ## No Background necessary.
 
  @ui
  Scenario: text based description of the gene appears in a user-friendly way
-    Given I go to page "/gene/OMIM:168600"
-     then the "Overview" tab should contain "Parkinson disease was first described by James Parkinson"
+    Given I go to page "/gene/OMIM:168600#overview"
+     then the "Info" tab should contain "Parkinson disease was first described by James Parkinson"

--- a/tests/behave/steps/selenium-autocomplete.py
+++ b/tests/behave/steps/selenium-autocomplete.py
@@ -27,6 +27,10 @@ def text_to_input(context, elt_id, text):
 def step_impl(context, text):
     text_to_input(context, 'home_search', text)
 
+@given('I type "{text}" into the navbar search')
+def step_impl(context, text):
+    text_to_input(context, 'search', text)
+
 @given('I type "{text}" into the phenotype analyze search')
 def step_impl(context, text):
     text_to_input(context, 'analyze_auto_input', text)

--- a/tests/behave/steps/selenium-basic.py
+++ b/tests/behave/steps/selenium-basic.py
@@ -67,17 +67,18 @@ def step_impl(context, clss, text):
 @then('the "{tabname}" tab should contain "{text}"')
 def step_impl(context, tabname, text):
     #print(context.browser.title)
-    #print(title)
     webelts = context.browser.find_elements_by_class_name("tab")
+    found_tab = False
     for w in webelts:
         if w.text.rfind(tabname) != -1:
+            found_tab = True
             parent = w.find_element_by_xpath("..")
             tab_href = parent.get_attribute("href")
             url = urlparse(tab_href)
             tab_id = url.fragment
             #print(tab_id)
             tab_area_elt = context.browser.find_element_by_id(tab_id)
-            #print(tab_area_elt)
+            #print(tab_area_elt.text)
             assert tab_area_elt and tab_area_elt.text.rfind(text) != -1
-        else:
-            assert 1 == 0
+    assert found_tab
+

--- a/tests/behave/steps/selenium-forms.py
+++ b/tests/behave/steps/selenium-forms.py
@@ -21,6 +21,13 @@ def step_impl(context):
     webelt = context.browser.find_element_by_id('home_search_form')
     webelt.submit()
 
+## Submit navbar search.
+@given('I submit navbar search')
+def step_impl(context):
+    #print(context.browser.title)
+    webelt = context.browser.find_element_by_id('search_form')
+    webelt.submit()
+
 ###
 ### Example for input for a possible text area form.
 ###


### PR DESCRIPTION
This commit is a set of changes to the layout of the home page and the navbar of other pages. I have other changes in the works, but this is a conservative set of changes that improve the consistency of the navbar and footer layouts, and also addresses some of the home page issues.

The initial motivation was this Issue:
   https://github.com/monarch-initiative/monarch-app/issues/842
The Navbar and footer consistency work was to ensure no 'flash' or 'jitter' when transitioning between the home and other pages.

High-level summary:
- Basic search moved to navbar on the home page. The radionale is that the navbar-search is on every page,
  and that this allows the Advanced Search via Phenotype Analysis to be emphasized.
- The carousel has been cleaned to remove the 'More' button, and to ensure that the text for all 4 sections wraps correctly.
- The carousel Icons are now clickable, as is the section title. This is in lieu of having the 'More' button.
- The Monarch logo icon has been placed in an identical location on all Navbars.
- Logo and Monarch Brand name are now aligned nicely. Previously, the 'Monarch' dropped below the baseline of the other Navbar occupants.
- Various typos and inconsistencies cleaned up
- Navbars and Footers are now all provided by navbar.mustache and footer.mustache, instead of having duplicates of this code.

Not yet accomplished:
- The Twitter/News area needs work. The Twitter iframe provides limited control over its dimensions, and it is being placed into our layout grid without participating in the geometry management. I have some ideas, but wanted to get this commit in first.
- The alignment of panel bottoms is not completed yet, and is related to the Twitter area issue.

Detailed Code Changes:
- Adds a monarch-navbar CSS class to ensure a narrow navbar with correct padding
- Improves CSS for the footer so that code reuse is possible via footer.mustache. The .fadeable subclass of .footer is used to implement the footer-fade-feature, which is controllable via a parameter when using footer.mustache.
- Adds .monarch-carousel-explore-title CSS class to implement the clickable section title.
- Positions the carousel icons to be top-aligned with the section title
- Modifies addCoreRenderers (webapp.js) so that defaults can be provided. This is currently used for the following properties:
   monarch_nav_search_p - Is there a search box on the navbar
   monarch_extra_footer_p - Is there an extra footer (the home page has one)
   monarch_footer_fade_p - Should the footer only appear on hover (home page and landing pages do not 'fade', other pages have 'fade').
  Using the 'defaults' parameter is now the appropriate way to override the behavior of addCoreRenderers(), rather than the previous technique:
    addCoreRenderers(info);
    info.monarch_nav_search_p = false;
    info.monarch_extra_footer_p = true;
- Removes obsolete update_dependencies.sh from start-server-dev.sh
- Replaces copied include of footer text with templated include of footer.mustache
- Updates Twitter Javascript fragment to latest version from TwitterCo
- Disables via comments the Basic Search Form in the home page and emphasizes the Advanced Phenotype Search.
- Fixes likely typo: 'containter-fluid' --> 'container-fluid'
- Removes copy of Navbar code from monarch-base-bs3.mustache and instead uses navbar.mustache.
- Removes copy of Footer code from monarch-base-bs3.mustache and instead uses footer.mustache.
