### PR TITLE
- Adds new step type to behave that allows for waiting on a DOM id. - Adds a maui_phenogrid test. - Moves implicitly_wait to environment.py, where it establishes a wait time for the session. - Note that the implicitly_wait doesn't seem to work in all cases, which is why the explicit wait step was added in the 'slow page' step. - Adds set_window_size to the webdriver instance so that PhantomJS can 'see' the autocomplete field.

### DIFF
--- a/tests/behave/environment.py
+++ b/tests/behave/environment.py
@@ -6,6 +6,7 @@
 ####
 
 import os
+import time
 from selenium import webdriver
 
 ###
@@ -20,12 +21,26 @@ def before_all(context):
         context.target = os.environ['TARGET']
     if 'BROWSER' in os.environ and os.environ['BROWSER'] == 'phantomjs':
         context.browser = webdriver.PhantomJS()
+        print("# Using PhantomJS")
     else:
         context.browser = webdriver.Firefox()
+    #
+    # Set a 30 second implicit wait - http://selenium-python.readthedocs.org/en/latest/waits.html#implicit-waits
+    # Once set, the implicit wait is set for the life of the WebDriver object instance.
+    #
+    context.browser.set_window_size(1440, 900)
+    context.browser.implicitly_wait(30) # seconds
 
 ## Do this after completing everything.
 def after_all(context):
     context.browser.quit()
+
+# Run this before each scenario
+# This works around a problem where the maui_gene test works fine independently, but
+# seems to fail randomly when run after the last test in maui_basic.
+# def before_scenario(context, scenario):
+#     time.sleep(1)
+
 
 ###
 ### Working on a more complex run environment for the future.

--- a/tests/behave/maui_gene.feature
+++ b/tests/behave/maui_gene.feature
@@ -5,5 +5,6 @@ Feature: Gene page description
 
  @ui
  Scenario: text based description of the gene appears in a user-friendly way
-    Given I go to page "/gene/OMIM:168600#overview"
-     then the "Info" tab should contain "Parkinson disease was first described by James Parkinson"
+    Given I go to slow page "/gene/OMIM:168600#overview" and wait for id "compare"
+     then the "Overview" tab should contain "Parkinson disease was first described by James Parkinson"
+

--- a/tests/behave/maui_phenogrid.feature
+++ b/tests/behave/maui_phenogrid.feature
@@ -1,0 +1,25 @@
+Feature: Phenogrid Works
+ The several places where Phenogrid appears are properly loaded.
+
+ ## No Background necessary.
+
+ @ui
+ Scenario: Phenotype Analysis Phenogrid works
+    Given I go to slow page "/disease/OMIM:105830" and wait for id "pg_svg_area"
+      then the title should be "Monarch Disease: Angelman syndrome (OMIM:105830)"
+      and the document should contain "Cross-Species Overview"
+
+@ui
+Scenario: Documentation example phenogrid appears
+   Given I go to page "/page/phenogrid"
+    then the title should be "Monarch Phenotype Grid Widget"
+
+@ui
+Scenario: Loading the iframe content for Monarch Phenotype Grid Widget loads a page with the correct title
+   Given I go to slow page "/node_modules/phenogrid/index.html" and wait for id "pg_svg_area"
+     then the title should be "Monarch Phenotype Grid Widget"
+     and the document should contain "Phenogrid is a Javascript component that visualizes"
+     and the document should contain "Phenotype Comparison (grouped by Mus musculus genes)"
+     and the document should contain "Fluctuations in consciousness"
+     and the document should contain "Bahcc1"
+

--- a/tests/behave/steps/selenium-autocomplete.py
+++ b/tests/behave/steps/selenium-autocomplete.py
@@ -42,7 +42,8 @@ def step_impl(context, text):
 def step_impl(context, item):
 
     ## Implicity poll for items to appear for 10 seconds.
-    context.browser.implicitly_wait(10)
+    # context.browser.implicitly_wait(20) setup in environment.py for session
+
     webelt = context.browser.find_element_by_partial_link_text(item)
 
     ## TODO: 

--- a/tests/behave/steps/selenium-basic.py
+++ b/tests/behave/steps/selenium-basic.py
@@ -4,12 +4,36 @@
 
 from behave import *
 from urlparse import urlparse
+import time
+import datetime
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait # available since 2.4.0
+from selenium.webdriver.support import expected_conditions as EC # available since 2.26.0
 
 ## The basic and critical "go to page".
 @given('I go to page "{page}"')
 def step_impl(context, page):
     #print(context.browser.title)
     context.browser.get(context.target + page)
+    # time.sleep(10)
+    # from selenium.webdriver.support import expected_conditions as EC
+    # wait = WebDriverWait(driver, 10)
+    # element = wait.until(EC.element_to_be_clickable((By.ID,'someid')))
+
+@given('I go to slow page "{page}" and wait for id "{id}"')
+def step_impl(context, page, id):
+    #print(context.browser.title)
+    context.browser.get(context.target + page)
+    #time.sleep(30)
+    element = WebDriverWait(context.browser, 60).until(EC.presence_of_element_located((By.ID, id)))
+    # try:
+    #     print(id)
+    #     element = WebDriverWait(context.browser, 30).until(EC.presence_of_element_located((By.ID, id)))
+    # finally:
+    #     print("FINALLY")
+    #     #context.browser.quit()
+
 
 ## Title check.
 @then('the title should be "{title}"')
@@ -27,10 +51,13 @@ def step_impl(context):
 ## The document body should contain a certain piece of text.
 @then('the document should contain "{text}"')
 def step_impl(context, text):
-    #print(context.browser.title)
-    #print(title)
+    print(context.browser.title)
     webelt = context.browser.find_element_by_tag_name('html')
+    print(webelt.text)
     assert webelt.text.rfind(text) != -1
+    # webelt = context.browser.find_element_by_tag_name('body')
+    # print(webelt.get_attribute('innerHTML'))
+    # assert webelt.get_attribute('innerHTML').rfind(text) != -1
 
 ## The document body should not contain a hyperlink with text.
 @then('the document should not contain link with "{text}"')
@@ -42,7 +69,7 @@ def step_impl(context, text):
     except NoSuchElementException:
         isNotFound = True
     assert isNotFound
-    
+
 ## The document body should not contain an internal hyperlink to {link}
 @then('the document should not contain an internal link to "{link}"')
 def step_impl(context, link):
@@ -62,11 +89,11 @@ def step_impl(context, clss, text):
     #print(title)
     webelt = context.browser.find_element_by_class_name(clss)
     assert webelt.text.rfind(text) != -1
-    
-## A given tab should contain a given piece of text/content. 
+
+## A given tab should contain a given piece of text/content.
 @then('the "{tabname}" tab should contain "{text}"')
 def step_impl(context, tabname, text):
-    #print(context.browser.title)
+    # print(context.browser.title)
     webelts = context.browser.find_elements_by_class_name("tab")
     found_tab = False
     for w in webelts:
@@ -76,9 +103,9 @@ def step_impl(context, tabname, text):
             tab_href = parent.get_attribute("href")
             url = urlparse(tab_href)
             tab_id = url.fragment
-            #print(tab_id)
+            # print(tab_id)
             tab_area_elt = context.browser.find_element_by_id(tab_id)
-            #print(tab_area_elt.text)
+            # print(tab_area_elt.text)
             assert tab_area_elt and tab_area_elt.text.rfind(text) != -1
     assert found_tab
 


### PR DESCRIPTION
- Adds new step type to behave that allows for waiting on a DOM id.
- Adds a maui_phenogrid test.
- Moves implicitly_wait to environment.py, where it establishes a wait time for the session.
- Note that the implicitly_wait doesn't seem to work in all cases, which is why the explicit wait step was added in the 'slow page' step.
- Adds set_window_size to the webdriver instance so that PhantomJS can 'see' the autocomplete field.

Verified via TravisCI and via PhantomJS on MacOSX.
