### PR TITLE
Ringo2node

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 ###
 
 ## Ringo
-RINGO_MODULE_PATH ?= ../stick/lib:./modules/
+RINGO_MODULE_PATH ?= ../stick/lib:./modules:./lib/monarch
 ## TODO/BUG: highly non-canonical location--should be passed as
 ## variable, not hard-coded.
 RINGO_BIN ?= ./tools/ringo

--- a/conf/resource_data_descriptions.json
+++ b/conf/resource_data_descriptions.json
@@ -158,5 +158,5 @@
   "id":"nif-0000-21427",
   "data_categories": "genotype-phenotype association; experimental reagents (morpholinos)",
   "monarch_use": "We integrate the curated genotype-phenotype data, including experimentally derived fish (such as via application of morpholions), and links to the literature as evidence.  "
-},
+}
 ]

--- a/conf/server_config_dev.json
+++ b/conf/server_config_dev.json
@@ -1,24 +1,13 @@
 {
     "type" : "dev",
-    
     "app_base" : "",
-    
     "ontology_services_url" : "http://nif-services-stage.neuinfo.org/ontoquest-lamhdi/",
-    
     "scigraph_url" : "http://geoffrey.crbs.ucsd.edu:9000/scigraph/",
-    
     "scigraph_data_url" : "http://rosie.crbs.ucsd.edu:9000/scigraph/",
-
     "golr_url" : "http://persei.monarchinitiative.org:8080/solr/golr/",
-
     "federation_services_url" : "http://beta.neuinfo.org/services/v1/federation/",
-
     "annotate_services_url" : "http://beta.neuinfo.org/services/v1/annotate/",
-    
     "autocomplete_url" : "http://beta.neuinfo.org/services/v1/vocabulary.json",
-
     "owlsim_services_url" : "http://owlsim.crbs.ucsd.edu/",
-    
     "analytics_id" : ""
-    
 }

--- a/lib/monarch/api.js
+++ b/lib/monarch/api.js
@@ -14,11 +14,18 @@
  *
  */
 
-
 // ========================================
 // SETUP
 // ========================================
-var fs = require('fs');
+
+var env = require('serverenv.js');
+var _ = require('underscore');
+
+if (!env.isRingoJS()) {
+    var AsyncRequest = require('request');
+    var WaitFor = require('wait.for');
+}
+
 var bbop = require('bbop');
 if (typeof bbop == 'undefined') { var bbop = {};}
 if (typeof bbop.monarch == 'undefined') { bbop.monarch = {};}
@@ -93,10 +100,9 @@ bbop.monarch.Engine = function(opts) {
 
     this.config.summary_categories = this.getConfig('summary_categories');
 
-    //this.log("config: "+JSON.stringify(this.config));
+    //this.log("api.js config: "+JSON.stringify(this.config));
 
-       // @Deprecated
-    if (typeof console != null) {
+    if (env.isRingoJS()) {
         // RingoJS
         this.fetchUrlImplementation = function(url) {
             var httpclient = require('ringo/httpclient');
@@ -107,12 +113,23 @@ bbop.monarch.Engine = function(opts) {
             return exchangeObj.content;
         };
     }
+    else {
+        this.fetchUrlImplementation = function(url) {
+            var requestResult = WaitFor.for(AsyncRequest.get, url);
+            return requestResult.body + '';
+        };
+    }
 
-    var subprocess = require('ringo/subprocess');
+    var subprocess = env.isRingoJS() ? require('ringo/subprocess') : null;
+
     this.debugInfo = 
         {
             dateServerStarted : new Date(Date.now()),
-            serverInfo : subprocess.command("uname -a"),
+            serverInfo :
+                env.isRingoJS() ?
+                    subprocess.command("uname -a")
+                    :
+                    require("child_process").exec('uname -a').unref(),
             apiVersionInfo : this.apiVersionInfo(),
         };
 
@@ -185,6 +202,7 @@ bbop.monarch.Engine.prototype.fetchDiseaseInfo = function(id, opts) {
                 this.log("cached version is out of date - will not use");
             }
             else {
+                //this.log("Found cached for "+id);
                 return cached;
             }
         }
@@ -1364,7 +1382,7 @@ bbop.monarch.Engine.prototype.fetchSpotlight = function(type, id) {
     }
 
     spotlight_data.label = info.label;
-    engine.log(JSON.stringify(spotlight_data));
+    //engine.log(JSON.stringify(spotlight_data));
 
     return spotlight_data;
 }
@@ -4026,17 +4044,17 @@ bbop.monarch.Engine.prototype.getMinScorePerCategory = function(categories) {
 bbop.monarch.Engine.prototype.searchByPhenotypeProfile = function(query,target_species,target_type,cutoff,metric) {
     var engine = this;
     var defaultMetric = 'combinedScore';
-    this.log("trying to search by phenotype profile...");
+    //this.log("trying to search by phenotype profile..." + JSON.stringify(query));
 
     var hashKey = engine.getPhenotypeProfileHashKey(query,target_species,target_type,
 						    cutoff,metric);
     this.log("trying to find cached entry for "+hashKey);
     if (this.cache != null) {
-	this.log("Checking cache for phenotype query..."+hashKey);
-	var cached = this.cache.fetch('phenotypeprofile',hashKey);
-	if (cached != null) {
-	    if (cached.apiVersionInfo == null ||
-		cached.apiVersionInfo != this.apiVersionInfo()) {
+        this.log("Checking cache for phenotype query..."+hashKey);
+        var cached = this.cache.fetch('phenotypeprofile',hashKey);
+        if (cached != null) {
+            if (cached.apiVersionInfo == null ||
+                cached.apiVersionInfo != this.apiVersionInfo()) {
                 this.log("cached version is out of date - will not use");
             }
             else {
@@ -4166,8 +4184,13 @@ bbop.monarch.Engine.prototype.getPhenotypeProfileHashKey  =
  */
 bbop.monarch.Engine.prototype.hashCode = function(str) {
 
-    var b64 = require('ringo/base64');
-    var input = b64.encode(str);
+    if (env.isRingoJS()) {
+        var b64 = require('ringo/base64');
+        var input = b64.encode(str);
+    }
+    else {
+        var input = Buffer(str).toString('base64');
+    }
 
     var hash = 5381;
     for (var i = 0; i < input.length; i++) {
@@ -6472,7 +6495,7 @@ bbop.monarch.Engine.prototype.fetchSimilarPapersFromPMID = function(id) {
 bbop.monarch.Engine.prototype.fetchDataDescriptions = function() {
 
     var t="resource_data_descriptions";
-    var sources = JSON.parse(fs.read('conf/'+t+'.json'));
+    var sources = JSON.parse(env.fs_readFileSync('conf/'+t+'.json'));
 
     //convert categories and ontologies to arrays
     for (var i=0;i<sources.length; i++) {
@@ -6548,23 +6571,8 @@ bbop.monarch.Engine.prototype.makePublicationList = function(r) {
  * Returns: string - may be JSON, XML, who knows
  */
 bbop.monarch.Engine.prototype.fetchUrl = function(url, params, method) {
-    var data = '';
-    if (params == null) {
-        params = {};
-    }
-    this.log("FETCHING: "+url+" data="+JSON.stringify(params));
-    var httpclient = require('ringo/httpclient');
-    // this.log("URL: "+url);
-    this._lastURL = url;
-    var exchangeObj;
-    if (method == 'post') {
-        exchangeObj =  httpclient.post(url, params);
-    }
-    else {
-        exchangeObj =  httpclient.get(url, params);
-    }
-    this.log("RESULT: "+exchangeObj);
-    this.log("STATUS: "+exchangeObj.status);
+    var exchangeObj = this.fetchUrlWithExchangeObject(url, params, method);
+
     if (exchangeObj.status != 200) {
         console.error("Status != 200. ExchangeObj source="+exchangeObj.toSource());
         throw({
@@ -6574,6 +6582,7 @@ bbop.monarch.Engine.prototype.fetchUrl = function(url, params, method) {
             message: "error fetching <"+url+"> response code=" + exchangeObj.status + " src="+exchangeObj.toSource()
         });
     }
+
     return exchangeObj.content;
 }
 
@@ -6595,23 +6604,53 @@ bbop.monarch.Engine.prototype.fetchUrlWithExchangeObject = function(url, params,
     if (params == null) {
         params = {};
     }
-    this.log("FETCHING: "+url+" data="+JSON.stringify(params));
-    var httpclient = require('ringo/httpclient');
-    // this.log("URL: "+url);
+    var timeDelta = Date.now();
+    this.log("FETCHING: " + method + " " +url+" params="+JSON.stringify(params));
     this._lastURL = url;
     var exchangeObj;
-    if (method == 'post') {
-        exchangeObj =  httpclient.post(url, params);
+    if (env.isRingoJS()) {
+        var httpclient = require('ringo/httpclient');
+        if (method == 'post') {
+            exchangeObj =  httpclient.post(url, params);
+        }
+        else {
+            exchangeObj =  httpclient.get(url, params);
+        }
     }
     else {
-        exchangeObj =  httpclient.get(url, params);
+        if (params && !_.isEmpty(params)) {
+            var querystring = require("querystring");
+            var uriparams = querystring.stringify(params);
+            url = url + '?' + uriparams;
+        };
+
+        if (method == 'post') {
+            var res = WaitFor.for(AsyncRequest.post, url);
+        }
+        else {
+            // For some reason, using the 'qs:' option results in array results being encoded weird.
+            //      "fq[0]":"subject_closure:\"DOID:0080001\"",
+            //      "fq[1]":"object_category:\"phenotype\"",
+            // instead of:
+            //  "fq":["subject_closure:\"DOID:0080001\"","object_category:\"phenotype\""],
+            //
+
+            var res = WaitFor.for(AsyncRequest.get, url);
+        }
+
+        exchangeObj = {
+            status: res.statusCode,
+            content: res.body.toString('utf-8')
+        };
     }
-    this.log("RESULT: "+exchangeObj);
-    this.log("STATUS: "+exchangeObj.status);
+
+    timeDelta -= Date.now();
+
+    this.log("FETCHED status: " + exchangeObj.status + "  Length: " + exchangeObj.content.length + "  Time: " +
+        timeDelta + "ms");
+
     return exchangeObj;
 }
-
-
 
 
 // very basic uniquifying of an array.
@@ -7105,7 +7144,7 @@ bbop.monarch.Engine.prototype.expandIdToURL = function(id) {
 }
 
 bbop.monarch.Engine.prototype.getConfig = function(t) {
-    var s = JSON.parse(fs.read('conf/'+t+'.json'));
+    var s = JSON.parse(env.fs_readFileSync('conf/'+t+'.json'));
     return s;
 }
 
@@ -7423,8 +7462,12 @@ bbop.monarch.Engine.prototype.fetchAssociations = function(id, field, filter, li
     var golrConf = new bbop.golr.conf(engine.config.golr);
     var golrServer = engine.config.golr_url;
     
-    var golrManager = new bbop.golr.manager.ringo(golrServer, golrConf);
-    
+    if (env.isRingoJS()) {
+        var golrManager = new bbop.golr.manager.ringo(golrServer, golrConf);
+    }
+    else {
+        var golrManager = new bbop.golr.manager.nodejs(golrServer, golrConf);
+    }
     if (personality != null){
         golrManager.set_personality(personality);
     }

--- a/lib/monarch/serverenv.js
+++ b/lib/monarch/serverenv.js
@@ -1,0 +1,78 @@
+// Utility function to determine NodeJS vs RingoJS runtime environment
+function isRingoJS() {
+  return (typeof(org) != 'undefined' && typeof(org.ringo) != 'undefined' );
+}
+var fs = require('fs');
+var fs_existsSync = isRingoJS() ?
+                        function(path) {
+                          var result = fs.exists(path);
+                          return result;
+                        }
+                      :
+                        function(path) {
+                          return fs.existsSync(path);
+                        };
+var fs_readFileSync = isRingoJS() ?
+                        function(path) {
+                          var result = fs.read(path);
+                          return result;
+                        }
+                      :
+                        function(path) {
+                          return fs.readFileSync(path);
+                        };
+var fs_readFileSyncBinary = isRingoJS() ?
+                        function(path) {
+                          var result = fs.read(path, {binary:true});
+                          return result;
+                        }
+                      :
+                        function(path) {
+                          return fs.readFileSync(path);
+                        };
+var fs_writeFileSync = isRingoJS() ?
+                        function(path, content) {
+                          var result = fs.write(path, content);
+                          return result;
+                        }
+                      :
+                        function(path, content) {
+                          return fs.writeFileSync(path, content);
+                        };
+var fs_listTreeSync = isRingoJS() ?
+                        function(path) {
+                          var result = fs.listTree(path);
+                          if (result && result.length > 0 && result[0] === '') {
+                            result.shift();
+                          }
+                          return result;
+                        }
+                      :
+                        function(path) {
+                          var glob = require("glob");
+                          var options = {
+                            //nodir: true,
+                            cwd: path
+                          };
+                          var rootPath = "**";
+                          var files = glob.sync(rootPath, options);
+                          return files;
+                        };
+var fs_unlinkSync = isRingoJS() ?
+                        function(path) {
+                          var result = fs.remove(path);
+                          return result;
+                        }
+                      :
+                        function(path) {
+                          return fs.unlinkSync(path);
+                        };
+
+exports.isRingoJS = isRingoJS;
+exports.fs_existsSync = fs_existsSync;
+exports.fs_readFileSync = fs_readFileSync;
+exports.fs_readFileSyncBinary = fs_readFileSyncBinary;
+exports.fs_writeFileSync = fs_writeFileSync;
+exports.fs_listTreeSync = fs_listTreeSync;
+exports.fs_unlinkSync = fs_unlinkSync;
+

--- a/lib/monarch/web/webapp.js
+++ b/lib/monarch/web/webapp.js
@@ -8,98 +8,211 @@
 
  */
 
-var stick = require('stick');
-var Mustache = require('mustache');
+var env = require('../serverenv.js');
+var web = require('./webenv.js');
 var fs = require('fs');
-var response = require('ringo/jsgi/response');
 
-var httpclient = require('ringo/httpclient');
-var http = require('ringo/utils/http');
-var file = require('ringo/utils/files');
-var strings = require('ringo/utils/strings');
+var Mustache = require('mustache');
+if (env.isRingoJS()) {
+  var stick = require('stick');
 
-var pup_tent = require('pup-tent')(['js','css','templates','templates/labs', 'templates/legacy',
-                                    'templates/page',
-                                    'widgets/dove/js',
-                                    'widgets/dove/lib',
-                                    'widgets/dove/css',
-                                    'node_modules/phenogrid/dist', // dist contains phenogrid-bundle.js and phenogrid-bundle.css
-                                    'node_modules/phenogrid/config', // config contains phenogrid_config.js
-                                    'widgets/keggerator/js',
-                                    'widgets/class-enrichment',
-                                    'conf', // get access to conf/golr-conf.json
-                                    'widgets/dove/js/model',
-                                    'widgets/dove/js/chart',
-                                    'widgets/dove/js/builder',
-                                    'widgets/dove/'
-                                    ]);
+  var response = require('ringo/jsgi/response');
 
-// Setup a little information capturing.
-var reporter = require('pup-analytics')();
+  var httpclient = require('ringo/httpclient');
+  var http = require('ringo/utils/http');
+  var file = require('ringo/utils/files');
+  var strings = require('ringo/utils/strings');
+}
+else {
+  var AsyncRequest = require('request');
+  var WaitFor = require('wait.for'); 
+}
 
-var app = exports.app = new stick.Application();
-app.configure('route');
-app.configure('params');
-app.configure('static');
 
-app.configure(require('./sanitize'));
-app.configure(require('./cors-middleware.js'));
+if (env.isRingoJS()) {
+  var pup_tent_loader = require('pup-tent');
+  var reporter = require('pup-analytics')();
+}
+else {
+  var pup_tent_loader = require('../../../modules/pup-tent/pup-tent.js');
+  var reporter = require('../../../modules/pup-analytics')();
+}
 
-var {isFileUpload, TempFileFactory, mergeParameter,
-    BufferFactory, getMimeParameter, Headers} = require("ringo/utils/http");
+var pup_tent = pup_tent_loader([
+                    'js',
+                    'css',
+                    'templates',
+                    'templates/labs',
+                    'templates/legacy',
+                    'templates/page',
+                    'widgets/dove',
+                    'widgets/dove/js',
+                    'widgets/dove/lib',
+                    'widgets/dove/css',
+                    'node_modules/phenogrid/node_modules/gfm.css', // dist contains phenogrid-bundle.js and phenogrid-bundle.css
+                    'node_modules/phenogrid/dist', // dist contains phenogrid-bundle.js and phenogrid-bundle.css
+                    'node_modules/phenogrid/config', // config contains phenogrid_config.js
+                    'node_modules/phenogrid/js/res',
+                    'widgets/keggerator/js',
+                    'widgets/class-enrichment',
+                    'conf', // get access to conf/golr-conf.json
+                    'widgets/dove/js/model',
+                    'widgets/dove/js/chart',
+                    'widgets/dove/js/builder'
+                    ]);
 
-/* Here we are overriding the upload function from stick's upload.js module
- * The stick module is hardcoded to use a BufferFactory for uploads, resulting
- * in large files causing memory issues.  Here we override the function using
- * a TempFileFactory from ringo/utils/http.js.  This streams the data into a 
- * temp file using the servers default tmp directory.  
- * 
- * We also set a limit of 50 mb by checking the content-length in
- * HTTP Header and override the parseFileUpload function to support a 
- * streaming limit as well.
- */
+if (env.isRingoJS()) {
+    var app = exports.app = new stick.Application();
+    app.configure('route');
+    app.configure('params');
+    app.configure('static');
+    app.configure(require('./sanitize'));
+    app.configure(require('./cors-middleware.js'));
 
-// Custom upload function to upload files to tmp file
-// Set upload limit to <50 MB using content-length from HTTP Header
-// Set streaming limit to <60 MB in case the content-length is incorrect
-app.configure (function upload(next, app) {
+    var http = require("ringo/utils/http");
+    var isFileUpload = http.isFileUpload;
+    var TempFileFactory = http.TempFileFactory;
+    var mergeParameter = http.mergeParameter;
+    var BufferFactory = http.BufferFactory;
+    var getMimeParameter = http.getMimeParameter;
+    var Headers = http.Headers;
 
-    app.upload = {
-        impl: TempFileFactory
-    };
+    /* Here we are overriding the upload function from stick's upload.js module
+     * The stick module is hardcoded to use a BufferFactory for uploads, resulting
+     * in large files causing memory issues.  Here we override the function using
+     * a TempFileFactory from ringo/utils/http.js.  This streams the data into a 
+     * temp file using the servers default tmp directory.  
+     * 
+     * We also set a limit of 50 mb by checking the content-length in
+     * HTTP Header and override the parseFileUpload function to support a 
+     * streaming limit as well.
+     */
 
-    return function upload(req) {
+    // Custom upload function to upload files to tmp file
+    // Set upload limit to <50 MB using content-length from HTTP Header
+    // Set streaming limit to <60 MB in case the content-length is incorrect
+    app.configure (function upload(next, app) {
 
-        var postParams, desc = Object.getOwnPropertyDescriptor(req, "postParams");
+        app.upload = {
+            impl: TempFileFactory
+        };
 
-        /**
-         * An object containing the parsed HTTP POST parameters sent with this request.
-         * @name request.postParams
-         */
-        Object.defineProperty(req, "postParams", {
-            get: function() {
-                if (!postParams) {
-                    var contentType = req.env.servletRequest.getContentType();
-                    if (req.headers['content-length'] > 50000000){
-                        postParams = {};
-                        postParams.file_exceeds = req.headers['content-length'];
-                    } else if ((req.method === "POST" || req.method === "PUT")
-                            && isFileUpload(contentType)) {
-                        postParams = {};
-                        var encoding = req.env.servletRequest.getCharacterEncoding();
-                        var byte_limit = 60000000;
-                        parseFileUploadWithLimit(this, postParams, encoding, TempFileFactory, byte_limit);
-                    } else if (desc) {
-                        postParams = desc.get ? desc.get.apply(req) : desc.value;
+        return function upload(req) {
+
+            var postParams, desc = Object.getOwnPropertyDescriptor(req, "postParams");
+
+            /**
+             * An object containing the parsed HTTP POST parameters sent with this request.
+             * @name request.postParams
+             */
+            Object.defineProperty(req, "postParams", {
+                get: function() {
+                    if (!postParams) {
+                        var contentType = req.env.servletRequest.getContentType();
+                        if (req.headers['content-length'] > 50000000){
+                            postParams = {};
+                            postParams.file_exceeds = req.headers['content-length'];
+                        } else if ((req.method === "POST" || req.method === "PUT")
+                                && isFileUpload(contentType)) {
+                            postParams = {};
+                            var encoding = req.env.servletRequest.getCharacterEncoding();
+                            var byte_limit = 60000000;
+                            parseFileUploadWithLimit(this, postParams, encoding, TempFileFactory, byte_limit);
+                        } else if (desc) {
+                            postParams = desc.get ? desc.get.apply(req) : desc.value;
+                        }
                     }
-                }
-                return postParams;
-            }, configurable: true
-        });
+                    return postParams;
+                }, configurable: true
+            });
 
-        return next(req);
+            return next(req);
+        };
+    });
+}
+else {
+    var Hapi = require('hapi');
+    var http = require('http');
+
+    // Create a server with a host and port
+    var app = new Hapi.Server();
+    app.connection({
+        host: 'localhost',
+        port: 8080
+    });
+
+    // Add routes
+
+    app.route({
+        method: 'GET',
+        path: '/js/{filename}',
+        handler: {
+            file: function (request) {
+                console.log('serving static:', '/js/' + request.params.filename);
+                return 'js/' + request.params.filename;
+            }
+        }
+    });
+
+    // More efficient than fs.readFileSync(), presumably
+    // app.route({
+    //     method: 'GET',
+    //     path: '/image/{filename}',
+    //     handler: {
+    //         file: function (request) {
+    //             console.log('serving static:', '/image/' + request.params.filename);
+    //             return 'image/' + request.params.filename;
+    //         }
+    //     }
+    // });
+
+    app.route({
+        method: 'GET',
+        path: '/css/{filename}',
+        handler: {
+            file: function (request) {
+                console.log('serving static:', '/css/' + request.params.filename);
+                return 'css/' + request.params.filename;
+            }
+        }
+    });
+
+    app.start(function () {
+        console.log('Server running at:', app.info.uri);
+    });
+
+    app.get = function (route, handler) {
+        var simpleRoute = route.indexOf(':') === -1;
+        var wrappedHandler =  function (request, reply) {
+                                WaitFor.launchFiber(handler, request, reply);
+                              };
+        if (simpleRoute) {
+            app.route({
+                method: 'GET',
+                path: route,
+                handler: wrappedHandler
+            });
+        }
+        else {
+            //console.log('#### PARAMETERIZED ROUTES NOT YET IMPLEMENTED:', route);
+        }
     };
-});
+
+    app.post = function (route, handler) {
+        var wrappedHandler =  function (request, reply) {
+                                WaitFor.launchFiber(handler, request, reply);
+                              };
+        var simpleRoute = route.indexOf(':') === -1;
+        if (simpleRoute) {
+            app.route({
+                method: 'POST',
+                path: route,
+                handler: wrappedHandler
+            });
+        }
+    };
+}
+
 
 //app.static("docs", "index.html", "/docs");
 
@@ -121,6 +234,7 @@ pup_tent.set_common('js_libs', [
     '/jquery.cookie.js',
     '/jquery.xml2json.js']);
 
+
 //note: in future this may conform to CommonJS and be 'require'd
 var engine = new bbop.monarch.Engine();
 
@@ -129,48 +243,63 @@ var js_re = /\.js$/;
 var css_re = /\.css$/;
 var json_re = /\.json$/;
 var html_re = /\.html$/;
+var png_re = /\.png$/;
 function _decide_content_type(thing){
     var ctype = null;
     if( js_re.test(thing) ){
-	ctype = 'text/javascript';
+        ctype = 'text/javascript';
     }else if( css_re.test(thing) ){
-	ctype = 'text/css';
+        ctype = 'text/css';
     }else if( json_re.test(thing) ){
         ctype = 'application/json';
     }else if( html_re.test(thing) ){
-	ctype = 'text/html';
+        ctype = 'text/html';
+    }else if( png_re.test(thing) ){
+        ctype = 'image/png';
     }else{
-	// "Unknown" type.
-	ctype = 'application/octet-stream';
+        // "Unknown" type.
+        ctype = 'application/octet-stream';
     }
     return ctype;
 }
 function _return_mapped_content(loc){
     var ctype = _decide_content_type(loc);
-    var str_rep = fs.read(loc);
+    var str_rep = env.fs_readFileSync(loc);
     return {
-	body: [str_rep],
-	headers: {'Content-Type': ctype},
-	status: 200
+    	body: [str_rep],
+    	headers: {'Content-Type': ctype},
+    	status: 200
     };
 }
 
 // Add routes for all static cache items at top-level.
 pup_tent.cached_list().forEach(
-    function(thing){
-        // This will skip cached templates.
-        var ctype = _decide_content_type(thing);
-        if( ctype !== null ){
+function(thing){
+    // This will skip cached templates.
+    var ctype = _decide_content_type(thing);
+    if( ctype !== null ){
+        if (env.isRingoJS()) {
             app.get('/' + thing,
-                function(req, page) {
-                return {
-                      body: [pup_tent.get(thing)],
-                      headers: {'Content-Type': ctype},
-                      status: 200
-                  };
+                function(req, repl) {
+                    return {
+                        body: [pup_tent.get(thing)],
+                        headers: {'Content-Type': ctype},
+                        status: 200
+                    };
                 });
         }
+        else {
+            app.get('/' + thing,
+                function(req, reply) {
+                    // console.log('###STATIC ', thing);
+                    return reply(pup_tent.get(thing))
+                              .type(ctype);
+                });
+        }
+    }
 });
+
+
 // When not in production, re-read files from disk--makes development
 // easier.
 if( ! engine.isProduction() ){
@@ -180,21 +309,21 @@ if( ! engine.isProduction() ){
 // note: this will probably move to it's own OO module
 engine.cache = {
     fetch: function(tbl, key, val) {
+        var result = null;
         var path = "./cache/"+tbl+"/key-"+key+".json";
-        //console.log("R lookup:"+path);
-        if (fs.exists(path)) {
-            //console.log("Using cached for:"+key);
-            return JSON.parse(fs.read(path));
+        if (env.fs_existsSync(path)) {
+            var content = env.fs_readFileSync(path);
+            result = JSON.parse(content);
         }
-        return null;
+        return result;
     },
     store: function(tbl, key, val) {
         var path = "./cache/"+tbl+"/key-"+key+".json";
         //console.log("S lookup:"+path);
-        fs.write(path, JSON.stringify(val));
+        env.fs_writeFileSync(path, JSON.stringify(val));
     },
     clear: function(match) {
-        var files = fs.listTree("cache");
+        var files = env.fs_listTreeSync("cache");
         for (var i=0; i<files.length; i++) {
             var file = files[i];
             console.log("T:"+file);
@@ -205,7 +334,7 @@ engine.cache = {
                 }
                 else {
                     console.log("CLEARING: " + file);
-                    fs.remove("./cache/" + file);
+                    env.fs_unlinkSync("./cache/" + file);
                 }
             }
         }
@@ -217,7 +346,7 @@ engine.cache = {
             this.cacheDirs().map(function(dir) {
                 console.log("Testing: "+dir);
                 return { id : dir,
-                         entries : fs.listTree("cache/"+dir).filter(function(f){ return f.indexOf(".json") > 0}).length,
+                         entries : env.fs_listTreeSync("cache/"+dir).filter(function(f){ return f.indexOf(".json") > 0}).length,
                          sizeOnfo : subprocess.command("du -sh cache/"+dir)
                        };
             });
@@ -225,23 +354,28 @@ engine.cache = {
         return info;
     },
     cacheDirs: function() {
-        return fs.listDirectoryTree("cache").filter(function(f){ return f.length > 0 });
-        //return fs.listTree("cache").filter(function(f){ return fs.isDirectory(f)});
+        if (env.isRingoJS()) {
+            return fs.listDirectoryTree("cache").filter(function(f){ return f.length > 0 });
+            //return env.fs_listTreeSync("cache").filter(function(f){ return fs.isDirectory(f)});
+        }
+        else {
+            console.log('cache.cacheDirs not supported for NodeJS yet. No equivalent to fs.listDirectoryTree');
+        }
     },
     contents: function() {
-        return fs.listTree("cache").filter(function(f){ return f.indexOf(".json") > 0});
+        return env.fs_listTreeSync("cache").filter(function(f){ return f.indexOf(".json") > 0});
     }
 };
 
 // STATIC HELPER FUNCTIONS. May become OO later.
 //o Deprecated with Pup tent
 function getTemplate(t) {
-    var s = fs.read('templates/'+t+'.mustache');
-    return s;
+    var s = env.fs_readFileSync('templates/'+t+'.mustache');
+    return s + '';
 }
 
 function getConfig(t) {
-    var s = JSON.parse(fs.read('conf/'+t+'.json'));
+    var s = JSON.parse(env.fs_readFileSync('conf/'+t+'.json'));
     return s;
 }
 
@@ -250,8 +384,7 @@ function staticTemplate(t) {
     addCoreRenderers(info);
     info.pup_tent_css_libraries.push("/monarch-main.css");
     var output = pup_tent.render(t+'.mustache',info);
-    return response.html(output);
-    //return response.html(Mustache.to_html(getTemplate(t), info));
+    return output;
 }
 
 function prepLandingPage() {
@@ -277,18 +410,6 @@ function loadBlogData(category, lim) {
   }
   return blog_res;
 }
-
-/*DELETEME
-function (loc,page,ctype) {
-    var s = fs.read(loc+'/'+page);
-    return {
-      body: [Mustache.to_html(s,{})],
-      headers: {'Content-Type': ctype},
-      status: 200
-   };
-}
-*/
-
 
 // This function takes a json representation of some data
 // (for example, a disease and various associated genes, phenotypes)
@@ -356,7 +477,7 @@ function addCoreRenderers(info, type, id, defaults){
     if( info['conf']['monarch-team'] == null ){
 	// Read in conf/monarch-team.json.
 	info['conf']['monarch-team'] =
-	    JSON.parse(fs.read('./conf/monarch-team.json'));
+	    JSON.parse(env.fs_readFileSync('./conf/monarch-team.json'));
     }
 
     if (info.relationships != null) {
@@ -436,27 +557,39 @@ function addPhenogridFiles(info) {
 // Takes JSON and returns an HTTP response, possibly translating
 // the JSON into a requested format.
 // Note that HTML is handled separately.
-function formattedResults(info, fmt,request) {
-    if (fmt == 'json') {
-        return response.json(info);
+function formattedResults(info, fmt, request) {
+    if (env.isRingoJS()) {
+        if (fmt == 'json') {
+            var jsonResult = response.json(info);
+            return jsonResult;
+        }
+        if (fmt == 'text') {
+            return response.text(info);
+        }
     }
-    if (fmt == 'text') {
-        return response.text(info);
+    else {
+        if (fmt == 'json') {
+            return web.wrapJSON(info);
+        }
+        else if (fmt == 'text') {
+            return web.wrapTEXT(info);
+        }
     }
+
     if (fmt == 'jsonp') {
-    // get callback name from parameters and wrap it around
-    //response.
-    /// consider replacing with response.jsonp once we got to
-    //ringo .10
-    var qs = request.queryString;
-    var params = http.parseParameters(qs);
-    callback = params.callback;
-    var resp  = callback+"("+JSON.stringify(info)+");";
-    return {
-        status: 200,
-        headers: {"Content-Type": "application/json"},
-        body: [resp]
-    };
+        // get callback name from parameters and wrap it around
+        //response.
+        /// consider replacing with response.jsonp once we got to
+        //ringo .10
+        var qs = request.queryString;
+        var params = http.parseParameters(qs);
+        callback = params.callback;
+        var resp  = callback+"("+JSON.stringify(info)+");";
+        return {
+            status: 200,
+            headers: {"Content-Type": "application/json"},
+            body: [resp]
+        };
     }
     else if (fmt == 'rdf' || fmt == 'nt') {
         // prepare  POST request to JSON-LD ==> RDF translator
@@ -485,6 +618,22 @@ function formattedResults(info, fmt,request) {
     }
 }
 
+var responseFormattedData = formattedResults;
+
+function responseError(s) {
+    if (env.isRingoJS()) {
+        return response.error(s);
+    }
+    else {
+        return {
+            body: [s],
+            headers: {'Content-Type': 'text/plain'},
+            status: 200
+        };
+    }
+}
+
+
 function errorResponse(msg) {
     var info = {};
     addCoreRenderers(info);
@@ -502,7 +651,6 @@ function errorResponse(msg) {
     info.title = 'Error';
     var output = pup_tent.render('notfound.mustache',info,'monarch_base.mustache');
     var res =  response.html(output);
-    //var res = response.html(Mustache.to_html(getTemplate('error'),info));
     res.status = 500;
     return res;
 }
@@ -524,7 +672,6 @@ function notFoundResponse(msg) {
     info.title = 'Error';
     var output = pup_tent.render('notfound.mustache',info,'monarch_base.mustache');
     var res =  response.html(output);
-    //var res = response.html(Mustache.to_html(getTemplate('error'),info));
     res.status = 404;
     return res;
 }
@@ -555,22 +702,26 @@ function notFoundResponse(msg) {
  * Returns:
  *  JSON response
  */
-app.get('/status', function(request) {
-    var status = {};
 
-    status['name'] = "Monarch Application";
-    status['okay'] =  true;
-    status['message'] =  'okay';
-    status['date'] = (new Date()).toString();
-    status['location'] = request.url || '???';
-    status['offerings'] = [
-	{'name': 'api_version', 'value': engine.apiVersionInfo()},
-	{'name': 'config_type', 'value': engine.config.type},
-	{'name': 'good_robot_hits', 'value': reporter.report('robots.txt')}
-    ];
+web.wrapRouteGet(app, '/status', '/status', [],
+    function(request) {
+        var status = {};
 
-    return response.json(status);
-});
+        status['name'] = "Monarch Application";
+        status['okay'] =  true;
+        status['message'] =  'okay';
+        status['date'] = (new Date()).toString();
+        status['location'] = request.url || request.pathInfo || '???';
+        status['offerings'] = [
+            {'name': 'api_version', 'value': engine.apiVersionInfo()},
+            {'name': 'config_type', 'value': engine.config.type},
+            {'name': 'good_robot_hits', 'value': reporter.report('robots.txt')}
+        ];
+
+        var output = web.wrapJSON(status);
+        return output;
+    }
+);
 
 // Method: /
 //
@@ -592,130 +743,114 @@ app.get('/labs/old-home', function(request) {
     return response.html(output);
 });
 
-// generic template
-app.get('/page/:page', function(request,page) {
-    var info = {};
-    addCoreRenderers(info);
 
-    if (!(page === 'software')){
-        info.pup_tent_css_libraries.push("/tour.css");
-    } else {
-        info.pup_tent_css_libraries.push("/monarch-main.css");
+web.wrapRouteGet(app, '/page/:page', '/page/{page}', ['page'],
+    function(request, page) {
+        var info = {};
+        addCoreRenderers(info);
+
+        if ((page !== 'software')){
+            info.pup_tent_css_libraries.push("/tour.css");
+        } else {
+            info.pup_tent_css_libraries.push("/monarch-main.css");
+        }
+
+        var output = pup_tent.render(page+'.mustache',info);
+        return web.wrapHTML(output);
     }
+);
 
-    var output = pup_tent.render(page+'.mustache',info);
-    return response.html(output);
-});
 
 // block unwanted access
-app.get('/robots.txt', function(request,page) {
-    var info = {};
-    addCoreRenderers(info);
-    reporter.hit('robots.txt');
+web.wrapRouteGet(app, '/robots.txt', '/robots.txt', [],
+    function(request) {
+        var info = {};
+        addCoreRenderers(info);
+        reporter.hit('robots.txt');
 
-    return {
-        status: 200,
-        headers: {"Content-Type": 'text/plain'},
-        //body: [Mustache.to_html(getTemplate('page/robots'), info)]
-        body: [pup_tent.apply('robots.mustache', info)]
-    };
-});
-
-// anything in the docs/ directory is passed through statically
-app.get('/docs/*', function(request) {
-    var path = request.pathInfo;
-    var ct = 'text/plain';
-    if (path.indexOf(".html") > 0) {
-        ct = "text/html";
+        return web.wrapTEXT(pup_tent.apply('robots.mustache', info));
     }
-    if (path.indexOf(".css") > 0) {
-        ct = "text/css";
-    }
-    return serveDirect(".", path, ct);
-    //return ('docs','files/js-api.html','text/html');
-});
-/*
- * This seems to be broken with the puptent update
- *
- * This can probably be deprecated
- *
-// CSS: pass-thru
-app.get('/css/:page', function(request,page) {
-    return ('css',page,'text/css');
-});
-// JS: pass-thru
-app.get('/js/:page', function(request,page) {
-   return ('js',page,'text/plain');
-});
-*/
-// IMG: pass-thru
-app.get('/image/:page', function(request,page) {
-    var s = fs.read('./image/'+page, {binary:true});
-    return {
-      body: [s],
-      headers: {'Content-Type': 'image/png'},
-      status: 200
-   };
-});
-
-app.get('/image/team/:page', function(request,page) {
-    var s = fs.read('./image/team/'+page, {binary:true});
-    return {
-      body: [s],
-      headers: {'Content-Type': 'image/png'},
-      status: 200
-   };
-});
-
-/*
- * DEPRECATED WITH PUPTENT
- * UNDEPRECATED DUE TO PUPTENT 
- *
- *  dedicated routing of the /node_modules/phenogrid was initially removed due to puptent,
- *  but this breaks phenogrid dependency on file structure.  Reinstate specific routing
- *  until such time as puptent is appropriately generalized
- */
+);
 
 
 // anything in the docs/ directory is passed through statically
-app.get('/node_modules/phenogrid/*', function(request) {
-    var path = request.pathInfo;
-    var ct = 'text/plain';
-    if (path.indexOf(".html") > 0) {
-    ct = "text/html";
+
+web.wrapRouteGet(app, '/docs/:dirname/:filename', '/docs/{dirname}/{filename}', ['dirname', 'filename'],
+    function(request, dirname, filename) {
+        var path = './docs/'+dirname + '/' + filename;
+        var ctype = _decide_content_type(path);
+        var s = env.fs_readFileSync(path) + '';
+        return web.wrapBinary(s, ctype);
     }
-    if (path.indexOf(".css") > 0) {
-    ct = "text/css";
+);
+
+web.wrapRouteGet(app, '/docs/:filename', '/docs/{filename*}', ['filename'],
+    function(request, filename) {
+        var path = './docs/'+filename;
+        var ctype = _decide_content_type(path);
+        var s = env.fs_readFileSync(path) + '';
+        return web.wrapHTML(s);
     }
-    return serveDirect(".", path, ct);
-});
+);
+
+web.wrapRouteGet(app, '/image/:page', '/image/{page}', ['page'],
+    function(request, page) {
+        var path = './image/'+page;
+        var ctype = _decide_content_type(path);
+        var s = env.fs_readFileSyncBinary(path) ;
+        return web.wrapBinary(s, ctype);
+    }
+);
+
+web.wrapRouteGet(app, '/image/team/:page', '/image/team/{page}', ['page'],
+    function(request, page) {
+        var path = './image/team/'+page;
+        var ctype = _decide_content_type(path);
+        var s = env.fs_readFileSyncBinary(path) ;
+        return web.wrapBinary(s, ctype);
+    }
+);
+
+web.wrapRouteGet(app, '/node_modules/phenogrid/image/:filename', '/node_modules/phenogrid/image/{filename}', ['filename'],
+    function(request, filename) {
+        var path = './node_modules/phenogrid/image/' + filename;
+        var ctype = _decide_content_type(path);
+        var s = env.fs_readFileSyncBinary(path);
+        return web.wrapBinary(s, ctype);
+    }
+);
+
+web.wrapRouteGet(app, '/node_modules/phenogrid/:filename', '/node_modules/phenogrid/{filename*}', ['filename'],
+    function(request, filename) {
+        var path = './node_modules/phenogrid/'+filename;
+        var ctype = _decide_content_type(path);
+        var s = env.fs_readFileSync(path) + '';
+        return web.wrapHTML(s);
+    }
+);
+
+
+//
+//  Miscellaneous utility functions that should be moved out of the way of the route defs
+//
+function renderPage(loc,page,ctype) {
+    var s = env.fs_readFileSync(loc+'/'+page) + '';
+    return Mustache.to_html(s, {});
+}
 
 /* needed to retain basic functionality for pass-through end run around puptent for phenogrid.*/
 function serveDirect(loc,page,ctype) {
-    var s = fs.read(loc+'/'+page);
-    return {
-    body: [Mustache.to_html(s,{})],
-    headers: {'Content-Type': ctype},
-    status: 200
-    };
+    // var body = env.fs_readFileSyncBinary(loc+'/'+page);
+    // var result = {
+    //         body: [body],
+    //         headers: {'Content-Type': ctype},
+    //         status: 200
+    //     };
+    var path = module.resolve('../../../' + loc+'/'+page);
+    var result = response.static(path, ctype);
+    return result;
 }
 
-
-//Phenogrid IMG: pass-thru
-app.get('/node_modules/phenogrid/image/:page', function(request,page) {
-     var path = request.pathInfo;
-     var ct = 'image/png';
-     if (path.indexOf(".gif") > 0) {
-         ct = "image/gif";
-     }
-     var s = fs.read('node_modules/phenogrid/image/'+page, {binary:true});
-     return {
-       body: [s],
-       headers: {'Content-Type': [ct]},
-       status: 200
-    };
-    return serverDirect('node_modules/phenogrid/image',page, ct);
-});
 
 // Get the query format (or null)
 function getQueryFormat(path) {
@@ -737,6 +872,11 @@ function getQueryTerm(path) {
   return path.substring(path.indexOf('/', 1) + 1);
 }
 
+
+//
+// Continue with route defs
+//
+
 // Method: search
 //
 // searches over ontology terms via SciGraph
@@ -751,15 +891,9 @@ function getQueryTerm(path) {
 //
 // Returns:
 //  All classes with :term as a substring
-app.get('/search/*', function(request) {
-    var path = request.pathInfo;
-    var term = getQueryTerm(path);
-    var fmt = getQueryFormat(path);
-    try {
-        if (request.params.search_term != null) {
-            term = request.params.search_term;
-        }
 
+function searchHandler(request, term, fmt) {
+    try {
         if (/^\s*\S+:\S+\s*$/.test(term)) {
             var url;
             engine.log("Redirecting " + term);
@@ -773,7 +907,7 @@ app.get('/search/*', function(request) {
                 //Fallback
                 url = genURL('object',term);
             }
-            return response.redirect(url);
+            return web.wrapRedirect(url);
         }
 
         // temporary fix: need to properly figure out when to encode/decode
@@ -782,7 +916,7 @@ app.get('/search/*', function(request) {
         var results = engine.searchOverOntologies(term);
         var info = {};
         info.results = results;
-        
+
         if (fmt != null) {
             return formattedResults(info, fmt);
         }
@@ -798,9 +932,8 @@ app.get('/search/*', function(request) {
         } else {
             info.resultsTable = "<span class=\"no-results\">&nbsp;&nbsp;No results found</span>";
         }
-           
+
         info.monarch_launchable = [];
-  
         info.monarch_launchable.push('search_results_init(searchTerm);');
 
         info.pup_tent_css_libraries.push("/monarch-specific.css");
@@ -808,13 +941,18 @@ app.get('/search/*', function(request) {
         info.title = 'Search Results: '+term;
 
         var output = pup_tent.render('search_results.mustache',info,'monarch_base.mustache');
-        return response.html(output);
+        console.log('xsearch:', output);
+        return web.wrapHTML(output);
     }
     catch(err) {
         return errorResponse(err);
     }
+}
 
-});
+// Order matters here in the declaration of these routes.
+web.wrapRouteGet(app, '/search/:term.:fmt?', '/search/{term}.{fmt}', ['term', 'fmt'], searchHandler);
+web.wrapRouteGet(app, '/search/:term', '/search/{term}', ['term'], searchHandler);
+
 
 //Method: search over NIF
 //
@@ -830,10 +968,7 @@ app.get('/search/*', function(request) {
 //
 // Returns:
 //  All classes with :term as a substring
-app.get('/neurosearch/*', function(request) {
-    var path = request.pathInfo;
-    var term = getQueryTerm(path);
-    var fmt = getQueryFormat(path);
+function neurosearchHandler(request, term, fmt) {
     try {
         if (request.params.search_term != null) {
             term = request.params.search_term;
@@ -841,7 +976,7 @@ app.get('/neurosearch/*', function(request) {
 
         if (/^\s*\S+:\S+\s*$/.test(term)) {
             engine.log("Redirecting" + term);
-            return response.redirect(genURL('object',term));
+            return web.wrapRedirect(genURL('object',term));
         }
 
         // temporary fix: need to properly figure out when to encode/decode
@@ -878,17 +1013,22 @@ app.get('/neurosearch/*', function(request) {
         info.title = 'NIF Search Results: '+term;
 
         var output = pup_tent.render('search_results.mustache',info,'monarch_base.mustache');
-        return response.html(output);
+        return web.wrapHTML(output);
     }
     catch(err) {
-        return errorResponse(err);
+        return formattedError(err);
     }
+}
 
-});
+
+// Order matters here in the declaration of these routes.
+web.wrapRouteGet(app, '/neurosearch/:term.:fmt?', '/neurosearch/{term}.{fmt}', ['term', 'fmt'], neurosearchHandler);
+web.wrapRouteGet(app, '/neurosearch/:term', '/neurosearch/{term}', ['term'], neurosearchHandler);
+
 
 //list all of the sources supplying data to monarch.
-app.get('/sources.:fmt?', function(request, fmt) {
-try {
+function sourcesHandler(request, fmt) {
+    try {
         //fetch data description json
         var sources = engine.fetchDataDescriptions();
         var info = {};
@@ -900,20 +1040,22 @@ try {
             return formattedResults(sources, fmt,request);
         }
 
-
         info.pup_tent_css_libraries.push("/monarch-specific.css");
         info.pup_tent_css_libraries.push("/sources.css");
         info.title = 'Data Sources';
 
         var output = pup_tent.render('sources.mustache',info,'monarch_base.mustache');
-        return response.html(output);
+        return web.wrapHTML(output);
     }
     catch(err) {
         return errorResponse(err);
     }
+}
 
+// Order matters here in the declaration of these routes.
+web.wrapRouteGet(app, '/sources.:fmt?', '/sources.{fmt}', ['fmt'], sourcesHandler);
+web.wrapRouteGet(app, '/sources', '/sources', [], sourcesHandler);
 
-});
 
 // Method: autocomplete
 //
@@ -931,12 +1073,14 @@ try {
 // Returns:
 //  List of matching objects
 
-app.get('/autocomplete/:category/:term.:fmt?',function(request,category,term,fmt) {
+
+function autocompleteByCategoryTermHandler(request,category,term,fmt) {
     // todo - we would like to normalize possible categories; e.g. phenotype --> Phenotype
     var info = engine.searchSubstring(term, category);
-    // todo - DRY - reuse code from below
-    //engine.log("got autocomplete results..."+info.length);
-    //if (info.length > 0) { console.log("first is: "+info[0].term); }
+    // engine.log("got autocomplete results..."+info.length);
+    // if (info.length > 0) {
+    //     console.log("first is: ", info[0]);
+    // }
     if (fmt != null) {
         //engine.log("format is "+fmt);
         var res= formattedResults(info,fmt,request);
@@ -947,23 +1091,21 @@ app.get('/autocomplete/:category/:term.:fmt?',function(request,category,term,fmt
             status: 500
         };
     }
-});
+}
+
+// Order matters here in the declaration of these routes.
+web.wrapRouteGet(app, '/autocomplete/:category/:term.:fmt?', '/autocomplete/{category}/{term}.{fmt}', ['category', 'term', 'fmt'], autocompleteByCategoryTermHandler);
+web.wrapRouteGet(app, '/autocomplete/:category/:term', '/autocomplete/{category}/{term}', ['category', 'term'], autocompleteByCategoryTermHandler);
 
 
-app.get('/autocomplete/:term.:fmt?',function(request,term,fmt) {
-    var info = engine.searchSubstring(term);
-    //if (info.length > 0) { engine.log("first is: "+info[0].term); }
-    if (fmt != null) {
-        //console.log("format is "+fmt);
-        var res= formattedResults(info,fmt,request);
-        return res;
-    } else {
-        return {
-            body: [ "Cannot handle format/extension: "+fmt],
-            status: 500
-        };
-    }
-});
+function autocompleteByTermHandler(request,term,fmt) {
+    return autocompleteByCategoryTermHandler(request, null, term, fmt);
+}
+
+// Order matters here in the declaration of these routes.
+web.wrapRouteGet(app, '/autocomplete/:term.:fmt?', '/autocomplete/{term}.{fmt}', ['term', 'fmt'], autocompleteByTermHandler);
+web.wrapRouteGet(app, '/autocomplete/:term', '/autocomplete/{term}', ['term'], autocompleteByTermHandler);
+
 
 
 // Method: disease
@@ -997,18 +1139,18 @@ app.get('/autocomplete/:term.:fmt?',function(request,term,fmt) {
 // Returns:
 //  Disease with matching ID
 
-app.get('/disease', function(request) {
-        var info = prepLandingPage();
-        info.blog_results = loadBlogData('disease-news', 4);
+app.get('/disease', function(request, reply) {
+    var info = prepLandingPage();
+    info.blog_results = loadBlogData('disease-news', 4);
 
     info.spotlight = engine.fetchSpotlight('disease');
     //info.spotlight.link = genObjectHref('disease',{id:info.spotlight.id, label:"Explore"});
-	info.spotlight.link = genObjectHref('disease',info.spotlight);
+    info.spotlight.link = genObjectHref('disease',info.spotlight);
 
     var heritability = info.spotlight.heritability;
     info.spotlight.heritability = info.spotlight.heritability.map(function(h) {return h.label}).join(", ");
 
-    var phenotypes = _sortByLabel(info.spotlight.phenotypes).map(function(p) genObjectHref('phenotype',p));
+    var phenotypes = _sortByLabel(info.spotlight.phenotypes).map(function(p) {return genObjectHref('phenotype',p);});
     info.spotlight.phenotypes = phenotypes.slice(0,5).join(", ");
     if (phenotypes.length > 5) {
         info.spotlight.phenotypes += ", <span class=\"toggleitems\"><span class=\"fewitems\"> [and "+(phenotypes.length-5)+" more...]</span><span class=\"moreitems\">";
@@ -1017,7 +1159,7 @@ app.get('/disease', function(request) {
     var genes = ['(none)'];
     if (info.spotlight.genes != null && info.spotlight.genes.length > 0) {
         info.spotlight.genes = _sortByLabel(info.spotlight.genes);
-        genes = info.spotlight.genes.map(function(p) genObjectHref('gene',p));
+        genes = info.spotlight.genes.map(function(p) {return genObjectHref('gene',p);});
     }
  
     info.spotlight.genes = genes.slice(0,5).join(", ");
@@ -1045,7 +1187,7 @@ app.get('/disease', function(request) {
     info.pup_tent_js_variables.push({name:'global_scigraph_url',
         value: engine.config.scigraph_url});
     
-    var diseaseDist = JSON.parse(fs.read('./widgets/dove/stats/DO-cache.json'));
+    var diseaseDist = JSON.parse(env.fs_readFileSync('./widgets/dove/stats/DO-cache.json'));
     info.pup_tent_js_libraries.push("/dove.min.js");
     info.pup_tent_js_libraries.push("/d3.3.5.5.min.js");
     info.pup_tent_css_libraries.push("/dovegraph.css");
@@ -1059,8 +1201,7 @@ app.get('/disease', function(request) {
     info.title = 'Monarch Diseases';
     
     var output = pup_tent.render('disease_main.mustache', info,'monarch_base.mustache');
-    var res =  response.html(output);
-    return res;
+    return web.wrapResponse(request, reply, web.wrapHTML(output));
 });
 
 
@@ -1072,7 +1213,7 @@ app.get('/legacy/disease/:id.:fmt?', function(request, id, fmt) {
         var newId = engine.resolveClassId(id);
         if (newId != id && typeof newId != 'undefined' ) {
             engine.log("redirecting: "+id+" ==> "+newId);
-            return response.redirect(genURL('disease',newId));
+            return web.wrapRedirect(genURL('disease',newId));
         }
         engine.log("Fetching id from engine, where cache="+engine.cache);
         var info = engine.fetchDiseaseInfo(id);
@@ -1241,7 +1382,7 @@ app.get('/legacy/disease/:id/:section.:fmt?', function(request, id, section, fmt
     var newId = engine.resolveClassId(id);
     if (newId != id) {
         engine.log("redirecting: "+id+" ==> "+newId);
-        return response.redirect(genURL('disease',newId));
+        return web.wrapRedirect(genURL('disease',newId));
     }
 
     var info = engine.fetchDiseaseInfo(id);
@@ -1290,7 +1431,7 @@ app.get('/legacy/disease/:id/:section.:fmt?', function(request, id, section, fmt
 // Returns:
 //  Phenotype with matching ID
 
-app.get('/phenotype', function(request) {
+app.get('/phenotype', function(request, reply) {
     var info = prepLandingPage();
     info.blog_results = loadBlogData('phenotype-news', 4);
    
@@ -1299,13 +1440,13 @@ app.get('/phenotype', function(request) {
     //info.spotlight.link = genObjectHref('phenotype',{id:info.spotlight.id, label:"Explore"});
     info.spotlight.link = genObjectHref('phenotype',info.spotlight);
 
-    var genes = _sortByLabel(info.spotlight.genes).map(function(g) genObjectHref('gene',g));
+    var genes = _sortByLabel(info.spotlight.genes).map(function(g) {return genObjectHref('gene',g);});
     info.spotlight.genes = genes.slice(0,5).join(", ");
     if (genes.length > 5) {
         info.spotlight.genes += ", <span class=\"toggleitems\"><span class=\"fewitems\"> [and "+(genes.length-5)+" more...]</span><span class=\"moreitems\">";
         info.spotlight.genes += genes.slice(5).join(", ") + "</span><span class=\"hideitems\"> [hide]</span></span>";
     }
-    var diseases = _sortByLabel(info.spotlight.diseases).map(function(p) genObjectHref('disease',p));
+    var diseases = _sortByLabel(info.spotlight.diseases).map(function(p) {return genObjectHref('disease',p);});
     if (diseases.length == 0) {
 		diseases = ['(none)'];
     }
@@ -1342,7 +1483,7 @@ app.get('/phenotype', function(request) {
     info.pup_tent_js_variables.push({name:'global_scigraph_url',
         value: engine.config.scigraph_url});
     
-    var phenoDist = JSON.parse(fs.read('./widgets/dove/stats/hp-ontology-4.json'));
+    var phenoDist = JSON.parse(env.fs_readFileSync('./widgets/dove/stats/hp-ontology-4.json'));
     info.pup_tent_js_libraries.push("/d3.3.5.5.min.js");
     info.pup_tent_css_libraries.push("/dovegraph.css");
     info.pup_tent_js_libraries.push("/dove.min.js");
@@ -1355,8 +1496,7 @@ app.get('/phenotype', function(request) {
     info.title = 'Monarch Phenotypes';
     
     var output = pup_tent.render('phenotype_main.mustache', info,'monarch_base.mustache');
-    var res =  response.html(output);
-    return res;
+    return web.wrapResponse(request, reply, web.wrapHTML(output));
 });
 
 app.get('/legacy/phenotype/:id.:fmt?', function(request, id, fmt) {
@@ -1658,7 +1798,7 @@ var fetchModelPage = function(request, id, fmt) {
     
         var output = pup_tent.render('model.mustache', info,
                                      'monarch_base.mustache');
-        return response.html(output);     
+        return web.wrapHTML(output);     
     }
     catch(err) {
         return errorResponse(err);
@@ -1801,8 +1941,8 @@ var genMGIXRef = function genMGIXRef(id){
             id + "\" target=\"_blank\">" + id + "</a>";
 };
 
-app.get('/genotype/:id.:fmt?',fetchGenotypePage);
-app.get('/legacy/genotype/:id.:fmt?',fetchLegacyGenotypePage);
+app.get('/genotype/:id.:fmt?', fetchGenotypePage);
+app.get('/legacy/genotype/:id.:fmt?', fetchLegacyGenotypePage);
 
 
 // GENOTYPE - Sub-pages
@@ -1812,7 +1952,7 @@ var fetchGenotypeSection =  function(request, id, section, fmt) {
     var newId = engine.resolveClassId(id);
     if (newId != id) {
         engine.log("redirecting: "+id+" ==> "+newId);
-        return response.redirect(genURL('genotype',newId));
+        return web.wrapRedirect(genURL('genotype',newId));
     }
 
     var info = engine.fetchGenotypeInfo(id);
@@ -1832,20 +1972,20 @@ var fetchGenotypeSection =  function(request, id, section, fmt) {
 
 app.get('/legacy/genotype/:id./:section.:fmt?',fetchGenotypeSection);
 
-app.get('/gene', function(request) {
+app.get('/gene', function(request, reply) {
     var info = prepLandingPage();
     info.blog_results = loadBlogData('gene-news', 4);
     info.spotlight = engine.fetchSpotlight('gene');
     //info.spotlight.link = genObjectHref('gene',{id:info.spotlight.id, label:"Explore"});
     info.spotlight.link = genObjectHref('gene',info.spotlight);
 
-    var phenotypes = _sortByLabel(info.spotlight.phenotypes).map(function(p) genObjectHref('phenotype',p));
+    var phenotypes = _sortByLabel(info.spotlight.phenotypes).map(function(p) {return genObjectHref('phenotype',p);});
     info.spotlight.phenotypes = phenotypes.slice(0,5).join(", ");
     if (phenotypes.length > 5) {
         info.spotlight.phenotypes += ", <span class=\"toggleitems\"><span class=\"fewitems\"> [and "+(phenotypes.length-5)+" more...]</span><span class=\"moreitems\">";
         info.spotlight.phenotypes += phenotypes.slice(5).join(", ") + "</span><span class=\"hideitems\"> [hide]</span></span>";
     }
-    var diseases = _sortByLabel(info.spotlight.diseases).map(function(p) genObjectHref('disease',p));
+    var diseases = _sortByLabel(info.spotlight.diseases).map(function(p) {return genObjectHref('disease',p);});
     if (diseases.length == 0) {
     diseases = ['(none)'];
     }
@@ -1873,8 +2013,8 @@ app.get('/gene', function(request) {
     info.pup_tent_js_variables.push({name:'global_scigraph_url',
         value: engine.config.scigraph_url});
     
-    var phenoDist = JSON.parse(fs.read('./widgets/dove/stats/hp-ontology-4.json'));
-    var diseaseDist = JSON.parse(fs.read('./widgets/dove/stats/DO-cache.json'));
+    var phenoDist = JSON.parse(env.fs_readFileSync('./widgets/dove/stats/hp-ontology-4.json'));
+    var diseaseDist = JSON.parse(env.fs_readFileSync('./widgets/dove/stats/DO-cache.json'));
     info.pup_tent_js_libraries.push("/dove.min.js");
     info.pup_tent_js_libraries.push("/d3.3.5.5.min.js");
     info.pup_tent_css_libraries.push("/dovegraph.css");
@@ -1890,8 +2030,7 @@ app.get('/gene', function(request) {
     info.title = 'Monarch Genes';
 
     var output = pup_tent.render('gene_main.mustache', info,'monarch_base.mustache');
-    var res =  response.html(output);
-    return res;
+    return web.wrapResponse(request, reply, web.wrapHTML(output));
 });
 
 // Status: STUB
@@ -1901,7 +2040,7 @@ app.get('/legacy/gene/:id.:fmt?', function(request, id, fmt) {
     var mappedID = getGeneMapping(id);
     if (typeof mappedID != 'undefined' && mappedID != id){
         engine.log("found updated ID, redirecting to: "+mappedID);
-        return response.redirect(genURL('gene',mappedID,fmt));
+        return web.wrapRedirect(genURL('gene',mappedID,fmt));
     }
 
     var info;
@@ -1996,7 +2135,7 @@ app.get('/legacy/gene/:id.:fmt?', function(request, id, fmt) {
     //return response.html(Mustache.to_html(getTemplate('gene'), info));
 });
 
-var fetchModelLandingPage = function (request){
+var fetchModelLandingPage = function (request, reply){
     
     var info = prepLandingPage();
     info.blog_results = loadBlogData('model-news', 4);
@@ -2006,13 +2145,13 @@ var fetchModelLandingPage = function (request){
     //info.spotlight.link = genObjectHref('model',{id:info.spotlight.id, label:"Explore"});
     info.spotlight.link = genObjectHref('model',info.spotlight);
 
-    var phenotypes = _sortByLabel(info.spotlight.phenotypes).map(function(p) genObjectHref('phenotype',p));
+    var phenotypes = _sortByLabel(info.spotlight.phenotypes).map(function(p) {return genObjectHref('phenotype',p);});
     info.spotlight.phenotypes = phenotypes.slice(0,5).join(", ");
     if (phenotypes.length > 5) {
         info.spotlight.phenotypes += ", <span class=\"toggleitems\"><span class=\"fewitems\"> [and "+(phenotypes.length-5)+" more...]</span><span class=\"moreitems\">";
         info.spotlight.phenotypes += phenotypes.slice(5).join(", ") + "</span><span class=\"hideitems\"> [hide]</span></span>";
     }
-    var diseases = _sortByLabel(info.spotlight.diseases).map(function(p) genObjectHref('disease',p));
+    var diseases = _sortByLabel(info.spotlight.diseases).map(function(p) {return genObjectHref('disease',p);});
     if (diseases.length == 0) {
     diseases = ['(none)'];
     }
@@ -2021,7 +2160,7 @@ var fetchModelLandingPage = function (request){
         info.spotlight.diseases += ", <span class=\"toggleitems\"><span class=\"fewitems\"> [and "+(diseases.length-5)+" more...]</span><span class=\"moreitems\">";
         info.spotlight.diseases += diseases.slice(5).join(", ") + "</span><span class=\"hideitems\"> [hide]</span></span>";
     }
-    var genes = _sortByLabel(info.spotlight.genes).map(function(g) genObjectHref('gene',g));
+    var genes = _sortByLabel(info.spotlight.genes).map(function(g) {return genObjectHref('gene',g);});
     info.spotlight.genes = genes.slice(0,5).join(", ");
     if (genes.length > 5) {
         info.spotlight.genes += ", <span class=\"toggleitems\"><span class=\"fewitems\"> [and "+(genes.length-5)+" more...]</span><span class=\"moreitems\">";
@@ -2042,7 +2181,7 @@ var fetchModelLandingPage = function (request){
     
     
     //graph
-    var hpStub = JSON.parse(fs.read('./widgets/dove/stats/hp-ontology-4.json'));
+    var hpStub = JSON.parse(env.fs_readFileSync('./widgets/dove/stats/hp-ontology-4.json'));
     info.pup_tent_js_libraries.push("/d3.3.5.5.min.js");
     info.pup_tent_css_libraries.push("/dovegraph.css");
     info.pup_tent_js_libraries.push("/barchart-launcher.js");
@@ -2056,8 +2195,7 @@ var fetchModelLandingPage = function (request){
     info.title = 'Monarch Models';
     
     var output = pup_tent.render('model_main.mustache', info,'monarch_base.mustache');
-    var res =  response.html(output);
-    return res;
+    return web.wrapResponse(request, reply, web.wrapHTML(output));
 }
 
 app.get('/model', fetchModelLandingPage);
@@ -2082,7 +2220,7 @@ app.get('/legacy/gene/:id/:section.:fmt?', function(request, id, section, fmt) {
     var mappedID = getGeneMapping(id);
     if (typeof mappedID != 'undefined' && mappedID != id){
         engine.log("found updated ID, redirecting to: "+mappedID);
-        return response.redirect(genURL('gene',mappedID,fmt));
+        return web.wrapRedirect(genURL('gene',mappedID,fmt));
     }
     var info = engine.fetchGeneInfo(id);
 
@@ -2100,25 +2238,53 @@ app.get('/legacy/gene/:id/:section.:fmt?', function(request, id, section, fmt) {
 });
 
 
-//For recieving of HPO relations for Phenogrid
+//For receiving of HPO relations for Phenogrid
 //Example: /neighborhood/HP_0003273/2/out/subClassOf.json
-app.get('/neighborhood/:id/:depth/:direction/:relationship.:fmt?', function(request, id, depth, direction, relationship, fmt) {
-    var info = engine.getGraphNeighbors(id, depth, relationship, direction);
 
-    if (fmt != null) {
-        return formattedResults(info, fmt, request);
-    }
-    else {
-        return response.error("plain HTML does not work for page sections. Please append .json or .rdf to URL");
-    }
-});
+function neighborhoodHandler(request, id, depth, direction, relationship, fmt) {
+  var info = engine.getGraphNeighbors(id, depth, relationship, direction);
+
+  if (fmt != null) {
+      return formattedResults(info, fmt, request);
+  }
+  else {
+      return formattedError("plain HTML does not work for page sections. Please append .json or .rdf to URL");
+  }
+}
+
+if (env.isRingoJS()) {
+  app.get('/neighborhood/:id/:depth/:direction/:relationship.:fmt?', function(request, id, depth, direction, relationship, fmt) {
+    var output = neighborhoodHandler(request, id, depth, direction, relationship, fmt);
+    return output;
+  });
+}
+else {
+  app.route({
+    method: 'GET',
+    path: '/neighborhood/{id}/{depth}/{direction}/{relationship}.{fmt?}',
+    handler:
+        function (request, reply) {
+          WaitFor.launchFiber(function () {
+            var id = request.params.id;
+            var depth = request.params.depth;
+            var direction = request.params.direction;
+            var relationship = request.params.relationship;
+            var fmt = request.params.fmt;
+
+            var output = neighborhoodHandler(request, id, depth, direction, relationship, fmt);
+            reply(output);
+          });
+        }
+  });
+}
 
 // Status: STUB
 // this just calls the genotype page - TODO
 app.get('/legacy/model/:id.:fmt?', fetchLegacyGenotypePage);
 app.get('/legacy/model/:id/:section.:fmt?', fetchGenotypeSection);
 
-app.get('/model/:id.:fmt?', fetchModelPage);
+web.wrapRouteGet(app, '/model/:id.:fmt?', '/model/{id}', ['id', 'fmt'], fetchModelPage);
+
 
 // Status: STUB
 // note we hardcode this for now
@@ -2187,9 +2353,9 @@ app.get('/compare/:x/:y.:fmt?', function(request, x, y, fmt) {
 // Redirects
 app.get('/reference/:id.:fmt?', function(request, id, fmt) {
     //var info = engine.fetchReferenceInfo(id);  TODO
-    //return response.redirect(engine.expandIdToURL(id));
+    //return web.wrapRedirect(engine.expandIdToURL(id));
     var url = makeExternalURL(id);
-    return response.redirect(url);
+    return web.wrapRedirect(url);
 });
 
 // STUB
@@ -2222,11 +2388,11 @@ app.get('/legacy/variant/:id.:fmt?', function(request, id, fmt) {
         url = makeExternalURL(id);
     }
     engine.log("redirecting: "+id+" to source at "+url);
-    return response.redirect(url);
+    return web.wrapRedirect(url);
 });
 
-app.get('/class', function(request) {
-    return staticTemplate('class_main');
+app.get('/class', function(request, reply) {
+    return web.wrapResponse(request, reply, web.wrapHTML(staticTemplate('class_main')));
 });
 
 // generic ontology view - most often this will be overridden, e.g. a disease class
@@ -2255,8 +2421,8 @@ app.get('/class/:id.:fmt?', function(request, id, fmt) {
     return response.html(Mustache.to_html(getTemplate('class'), info));
 });
 
-app.get('/anatomy', function(request) {
-    return staticTemplate('anatomy_main');
+app.get('/anatomy', function(request, reply) {
+    return web.wrapResponse(request, reply, web.wrapHTML(staticTemplate('anatomy_main')));
 });
 
 app.get('/anatomy/:id.:fmt?', function(request, id, fmt) {
@@ -2302,8 +2468,8 @@ app.get('/anatomy/:id.:fmt?', function(request, id, fmt) {
 });
 
 /* Literature Pages */
-app.get('/literature', function(request) {
-    return staticTemplate('literature_main');
+app.get('/literature', function(request, reply) {
+    return web.wrapResponse(request, reply, web.wrapHTML(staticTemplate('literature_main')));
 });
 
 app.get('/literature/:id.:fmt?', function(request, id, fmt) {
@@ -2353,7 +2519,6 @@ app.get('/literature/:id.:fmt?', function(request, id, fmt) {
 });
 
 function getIdentifierList(params) {
-    //engine.log("Params="+JSON.stringify(params));
     var input_items;
     if (params.a != null) {
         input_items = params.a;
@@ -2428,7 +2593,7 @@ app.post('/score', scoreFunction);
 // Returns:
 //  List of matching entities
 
-app.get('/simsearch/disease/:id.:fmt?', function(request,id,fmt) {
+function simsearchDiseaseById(request, id, fmt) {
     engine.log("Params:"+JSON.stringify(request.params));
     var target = null;
     var info = {datatype: 'disease', results:[]};
@@ -2437,42 +2602,121 @@ app.get('/simsearch/disease/:id.:fmt?', function(request,id,fmt) {
     var limit = request.params.cutoff || request.params.limit || 10;
 
     info.results = engine.searchByDisease(id,target_species,limit);
-    return response.json(info.results);
+    return info.results;
+}
 
-});
 
-var simsearch = function(request, fmt) {
+if (env.isRingoJS()) {
+    app.get('/simsearch/disease/:id.:fmt?', function (request, id, fmt) {
+            var output = simsearchDiseaseById(request, id, fmt);
+            return web.wrapResponse(request, null, web.wrapJSON(output));
+        }
+    );
+}
+else {
+    app.route({
+        method: 'GET',
+        path: '/simsearch/disease/{id}.{fmt?}',
+        handler:
+            function (request, reply) {
+              WaitFor.launchFiber(function () {
+                var id = request.params.id;
+                var fmt = request.params.fmt;
+                var output = simsearchDiseaseById(request, id, fmt);
+                return web.wrapResponse(request, reply, web.wrapJSON(output));
+              });
+            }
+    });
+}
+
+
+
+var simsearchPhenotype = function(request, fmt, target_species, target_type, limit, input_items) {
     var target = null;
     var info = {results:[]};
-    var target_species = request.params.target_species; //|| '9606'; //default to human
-    var target_type = request.params.target_type; //|| 'disease';
-    var limit = request.params.cutoff || request.params.limit || 100;
-    var input_items = getIdentifierList(request.params);
     //input_items = engine.mapIdentifiersToPhenotypes( input_items );
     info.results = engine.searchByPhenotypeProfile(input_items,target_species,null,limit);
 
-    return response.json(info.results);
+    return info.results;
 
 };
 
-app.get('/simsearch/phenotype.:fmt?', simsearch);
-app.post('/simsearch/phenotype.:fmt?', simsearch);
+if (env.isRingoJS()) {
+    app.get('/simsearch/phenotype.:fmt?', function (request, fmt) {
+            var target_species = request.params.target_species; //|| '9606'; //default to human
+            var target_type = request.params.target_type; //|| 'disease';
+            var limit = request.params.cutoff || request.params.limit || 100;
+            var input_items = getIdentifierList(request.params);
 
-app.get('/annotate/text.:fmt?', function(request, fmt) {
-    var q = request.params.q;
+            var output = simsearchPhenotype(request, fmt, target_species, target_type, limit, input_items);
+            return response.json(output);
+        }
+    );
+    app.post('/simsearch/phenotype.:fmt?', function (request, fmt) {
+            var target_species = request.params.target_species; //|| '9606'; //default to human
+            var target_type = request.params.target_type; //|| 'disease';
+            var limit = request.params.cutoff || request.params.limit || 100;
+            var input_items = getIdentifierList(request.params);
+
+            var output = simsearchPhenotype(request, fmt, target_species, target_type, limit, input_items);
+            return response.json(output);
+        }
+    );
+}
+else {
+    app.route({
+        method: 'GET',
+        path: '/simsearch/phenotype.{fmt?}',
+        handler:
+            function (request, reply) {
+              WaitFor.launchFiber(function () {
+                var fmt = request.params.fmt;
+                var target_species = request.params.target_species; //|| '9606'; //default to human
+                var target_type = request.params.target_type; //|| 'disease';
+                var limit = request.params.cutoff || request.params.limit || 100;
+                var input_items = getIdentifierList(request.params);
+
+                var output = simsearchPhenotype(request, fmt, target_species, target_type, limit, input_items);
+                reply(output);
+              });
+            }
+    });
+    app.route({
+        method: 'POST',
+        path: '/simsearch/phenotype',
+        handler:
+            function (request, reply) {
+              WaitFor.launchFiber(function () {
+                var fmt = request.payload.fmt;
+                var target_species = request.payload.target_species; //|| '9606'; //default to human
+                var target_type = request.payload.target_type; //|| 'disease';
+                var limit = request.payload.cutoff || request.payload.limit || 100;
+                var input_items = getIdentifierList(request.payload);
+
+                var output = simsearchPhenotype(request, fmt, target_species, target_type, limit, input_items);
+                reply(output);
+              });
+            }
+    });
+}
+
+
+function annotateByTextHandler(request, fmt) {
+    var q = env.isRingoJS() ? request.params.q : request.query.q;
+    var longestOnly = env.isRingoJS() ? request.params.longestOnly : request.query.longestOnly;
 
     var pheno_ids = [];
     var info =
         {
             query: q,
-            longestOnly: request.params.longestOnly,
+            longestOnly: longestOnly,
             results:[],
         };
 
     if (q == null || q == "") {
     }
     else {
-        info.results = engine.annotateText(q, {longestOnly : request.params.longestOnly});
+        info.results = engine.annotateText(q, {longestOnly : longestOnly});
         info.results.forEach(function(r) {
             engine.log("RES:"+JSON.stringify(r));
             if (r.token.categories.indexOf('Phenotype') > -1) {
@@ -2551,8 +2795,11 @@ app.get('/annotate/text.:fmt?', function(request, fmt) {
     info.hasResults = (info.results.length > 0);
     //return response.html(Mustache.to_html(getTemplate('annotate'), info));
     var output = pup_tent.render('annotate.mustache',info,'monarch_base.mustache');
-    return response.html(output);
-});
+    return web.wrapHTML(output);
+}
+
+web.wrapRouteGet(app, '/annotate/text.:fmt?', '/annotate/text', ['fmt'], annotateByTextHandler);
+
 
 app.get('/annotate_minimal/text.:fmt?', function(request, fmt) {
     var q = request.params.q;
@@ -2660,9 +2907,14 @@ app.get('/admin/cache/info', function(request, fmt) {
 
 // in theory anyone could access this and clear our cache slowing things down....
 // we should make this authorized, not really a concern right now though
-app.get('/admin/clear-cache', function(request) {
+app.get('/admin/clear-cache', function(request, reply) {
     engine.cache.clear(request.params.match);
-    return response.html("Cleared!");
+    if (env.isRingoJS()) {
+        return response.html("Cleared!");
+    }
+    else {
+        reply("Cleared!");
+    }
 });
 
 // A routing page different non-production demonstrations and tests.
@@ -2722,8 +2974,8 @@ app.get('/labs/dovegraph.:fmt?',function(request,fmt){
         info.pup_tent_js_variables.push({name:'global_scigraph_url',
             value: engine.config.scigraph_url});
         
-        var phenoDist = JSON.parse(fs.read('./widgets/dove/stats/key-phenotype-annotation-distro.json'));       
-        var hpStub = JSON.parse(fs.read('./widgets/dove/stats/hp-ontology-4.json'));
+        var phenoDist = JSON.parse(env.fs_readFileSync('./widgets/dove/stats/key-phenotype-annotation-distro.json'));       
+        var hpStub = JSON.parse(env.fs_readFileSync('./widgets/dove/stats/hp-ontology-4.json'));
 
         if (fmt != null) {
             return formattedResults(info,fmt,request);
@@ -2849,76 +3101,121 @@ var _blog_data_last_res = [];
  * Get blog data
  * @param {String} label - An optional label restricting blog posts.
  */
-function _get_blog_data(label){
+function _get_blog_data(label) {
 
-    // Only proceed if the time-since-last threshold is crossed or the
-    // cached results are empty.
-    var res = [];
-    var now = _get_now_sec()
-    if( (now -_blog_data_last_time) < _blog_data_last_step &&
-    _blog_data_last_res.length > 0 ){
+  // Only proceed if the time-since-last threshold is crossed or the
+  // cached results are empty.
+  var res = [];
+  var now = _get_now_sec()
+  if( (now - _blog_data_last_time) < _blog_data_last_step && _blog_data_last_res.length > 0 ) {
     // Used cached list
     engine.log('blog: using cached results');
     res = _blog_data_last_res;
-    }else{
+  }
+  else {
     engine.log('blog: get new results');
 
     // Grab off page.
     var base = 'http://monarch-initiative.blogspot.com';
-  var catr = base + '/search/label/';
+    var catr = base + '/search/label/';
     var rsrc = base + '/feeds/posts/default?alt=rss';
-  if (null != label) {
-      rsrc = base + '/feeds/posts/default/-/' + label + '?alt=rss';
-  }
+    if (null != label) {
+        rsrc = base + '/feeds/posts/default/-/' + label + '?alt=rss';
+    }
 
-    try {
+    var rssContent = null;
+    if (env.isRingoJS()) {
+      try {
         var http_client = require("ringo/httpclient");
         var exchange = http_client.get(rsrc);
         if( exchange && exchange.content ){
-        var c = exchange.content;
-        //engine.log('got: ' + got);
-
-        // For E4X bug 336551.
-        c = c.replace(/^<\?xml\s+version\s*=\s*(["'])[^\1]+\1[^?]*\?>/, "");
-        var rss = new XML(c);
-        if( rss && rss.channel && rss.channel.item ){
-            for each( var item in rss.channel.item ) {
-            //engine.log('prop: ' + item.title);
-
-            // Date.
-            var t = new Date(item.pubDate);
-            var y = t.getFullYear();
-            var m = t.getMonth();
-            if( m < 10 ){ m = '0' + m; }
-            var d = t.getDate();
-
-            // Categories.
-            var cats = [];
-            for each( var cat in item.category ){
-                cats.push({'label': cat, 'link': catr + cat});
-            }
-
-            res.push({
-                'title': item.title,
-                'description': item.description,
-                'link': item.link,
-                'category': cats,
-                'date': [y, m, d].join('-')
-            });
-            }
+          rssContent = exchange.content;
+          // engine.log('rssContent: ' + rssContent);
         }
-        //engine.log('xml: ' + rss);
-        }
-    }catch (e){
+      }
+      catch (e) {
         engine.log('blog: error: ' + e);
-    }finally{
-        // No matter what, even if empty, update last attempt.
-        _blog_data_last_res = res;
-        _blog_data_last_time = now;
+      }
     }
+    else {
+      var requestResult = WaitFor.for(AsyncRequest.get, rsrc);
+      rssContent = requestResult.body + '';
     }
-    return res;
+
+    if (rssContent) {
+      // For E4X bug 336551.
+      rssContent = rssContent.replace(/^<\?xml\s+version\s*=\s*(["'])[^\1]+\1[^?]*\?>/, "");
+      // console.log('rssContent:', rssContent);
+
+      var rss;
+      if (false && env.isRingoJS()) {
+        rss = new XML(rssContent);
+      }
+      else {
+        var xml2js = require('xml2js');
+        var parseString = xml2js.parseString;
+        var parseOptions = {};
+        parseOptions.explicitArray = false;
+        parseOptions.ignoreAttrs = true;
+        parseString(rssContent, parseOptions, function (err, result) {
+            rss = result.rss;
+        });
+      }
+
+      // console.log('parsed rss:', rss);
+      // console.log('#### rss.channel:', rss.channel);
+      // console.log('#### rss.channel.item:', rss.channel.item);
+      if( rss && rss.channel && rss.channel.item ){
+        for (var itemkey in rss.channel.item) {
+          var item = rss.channel.item[itemkey];
+          //engine.log('item: ' + Object.keys(item) + ' --> ' + item);
+
+          // Date.
+          var t = new Date(item.pubDate);
+          var y = t.getFullYear();
+          var m = t.getMonth();
+          if ( m < 10 ) {
+              m = '0' + m;
+          }
+          var d = t.getDate();
+
+          // Categories.
+          var cats = [];
+
+          // Categories.
+          var cats = [];
+          if (item.category) {
+            var catarray = item.category;
+            if (typeof(catarray) === 'string') {
+                catarray = [catarray];
+            }
+            for( var catindex = 0; catindex < catarray.length; ++catindex ) {
+              var cat = catarray[catindex];
+              cats.push({'label': cat, 'link': catr + cat});
+            }
+          }
+
+          res.push({
+              'title': item.title,
+              'description': item.description,
+              'link': item.link,
+              'category': cats,
+              'date': [y, m, d].join('-')
+          });
+        }
+      }
+    }
+  }
+
+  // No matter what, even if empty, update last attempt.
+  _blog_data_last_res = res;
+  _blog_data_last_time = now;
+
+  return res;
 }
+
+
+
 
 function _sortByLabel(array) {
     if (array == null) return;
@@ -2939,38 +3236,62 @@ function _sortByLabel(array) {
 }
 
 
-app.get('/', function(request, page){
+function homeHandler(request) {
+  // Rendering.
+  var info = {};
 
-    // Rendering.
-    var info = {};
+  var defaults = {
+      monarch_nav_search_p: true,
+      monarch_extra_footer_p: true,
+      monarch_footer_fade_p: false
+  };
 
-    var defaults = {
-        monarch_nav_search_p: true,
-        monarch_extra_footer_p: true,
-        monarch_footer_fade_p: false
-    };
+  addCoreRenderers(info, null, null, defaults);
 
-    addCoreRenderers(info, null, null, defaults);
+  // Now add the stuff that we need to move forward.
+  //info.pup_tent_css_libraries.push("/bootstrap-glyphicons.css");
+  info.pup_tent_css_libraries.push("/monarch-home.css");
+  info.pup_tent_js_libraries.push("/HomePage.js");
 
-    // Now add the stuff that we need to move forward.
-    //info.pup_tent_css_libraries.push("/bootstrap-glyphicons.css");
-    info.pup_tent_css_libraries.push("/monarch-home.css");
-    info.pup_tent_js_libraries.push("/HomePage.js");
-    
-    // Get blog data and render with vars.
-    var blog_res = _get_blog_data();
-    // Limit to X.
-    var lim = 4;
-    if( blog_res && blog_res.length > lim ){
-        blog_res = blog_res.slice(0, lim);
-    }
-    info.blog_results = blog_res;
-    info.title = 'Welcome to Monarch';
-    var output = pup_tent.render('home-page.mustache', info,
-				 'monarch-base-bs3.mustache');
-    var res =  response.html(output);
-    return res;
-});
+  // Get blog data and render with vars.
+  var blog_res = _get_blog_data();
+  // Limit to X.
+  var lim = 4;
+  if( blog_res && blog_res.length > lim ){
+      blog_res = blog_res.slice(0, lim);
+  }
+  info.blog_results = blog_res;
+  info.title = 'Welcome to Monarch';
+  var output = pup_tent.render('home-page.mustache', info,
+       'monarch-base-bs3.mustache');
+  return output;
+}
+
+if (env.isRingoJS()) {
+    app.get('/',
+        function (request, id, fmt) {
+            try {
+                var output = homeHandler(request);
+                return response.html(output);
+            } catch(err) {
+                return errorResponse(err);
+            }
+        }
+    );
+}
+else {
+    app.route({
+        method: 'GET',
+        path: '/',
+        handler:
+            function (request, reply) {
+              WaitFor.launchFiber(function () {
+                var output = homeHandler(request);
+                reply(output);
+              });
+            }
+    });
+}
 
 app.get('/labs/scratch-homepage', function(request, page){
 
@@ -2990,7 +3311,7 @@ app.get('/labs/scratch-homepage', function(request, page){
     info.pup_tent_js_libraries.push("/HomePage.js");
     
     //graph
-    var phenoDist = JSON.parse(fs.read('./widgets/dove/stats/key-phenotype-annotation-distro.json'));
+    var phenoDist = JSON.parse(env.fs_readFileSync('./widgets/dove/stats/key-phenotype-annotation-distro.json'));
     info.pup_tent_js_libraries.push("/dovechart.js");
     info.pup_tent_js_libraries.push("/d3.3.5.5.min.js");
     info.pup_tent_css_libraries.push("/dovegraph.css");
@@ -3071,16 +3392,17 @@ function addGolrStaticFiles(info) {
 
 // query_field: e.g. subject_closure
 function addGolrTable(info, query_field, id, div, filter, personality, anchor) {
-    
+    var replacer = new RegExp('-', 'g');
+
     //There has to be a better way
-    var id_var = "query_id_" + bbop.core.uuid().replace('-','','g');
-    var field_var = "query_field_" + bbop.core.uuid().replace('-','','g');
-    var div_var = "query_div_" + bbop.core.uuid().replace('-','','g');
-    var filt_var = "filter_" + bbop.core.uuid().replace('-','','g');
-    var person_var = "person_" + bbop.core.uuid().replace('-','','g');
-    var anchor_var = "anchor_" + bbop.core.uuid().replace('-','','g');
+    var id_var = "query_id_" + bbop.core.uuid().replace(replacer, '');
+    var field_var = "query_field_" + bbop.core.uuid().replace(replacer, '');
+    var div_var = "query_div_" + bbop.core.uuid().replace(replacer, '');
+    var filt_var = "filter_" + bbop.core.uuid().replace(replacer, '');
+    var person_var = "person_" + bbop.core.uuid().replace(replacer, '');
+    var anchor_var = "anchor_" + bbop.core.uuid().replace(replacer, '');
     var launch = '';
-            
+
     info.pup_tent_js_variables.push({name: id_var, value: id});
     info.pup_tent_js_variables.push({name: field_var, value: query_field});
     info.pup_tent_js_variables.push({name: div_var, value: div});
@@ -3125,7 +3447,8 @@ app.get('/labs/widget-scratch',
         return res;
  });
 
-app.get('/phenotype/:id.:fmt?',
+
+web.wrapRouteGet(app, '/phenotype/:id.:fmt?', '/phenotype/{id}', ['id', 'fmt'],
         function(request, id, fmt){
 
             engine.log("PhenotypeID= "+id);
@@ -3134,7 +3457,7 @@ app.get('/phenotype/:id.:fmt?',
             if (/_/.test(id)){
                 engine.log("ID contains underscore, replacing with : and redirecting");
                 var newID = id.replace("_",":");
-                return response.redirect(genURL('phenotype',newID));
+                return web.wrapRedirect(genURL('phenotype',newID));
             }
 
             // Rendering.
@@ -3143,7 +3466,7 @@ app.get('/phenotype/:id.:fmt?',
             
             if (fmt != null) {
                 // TODO
-                return formattedResults(info, fmt,request);
+                return formattedResults(info, fmt, request);
             }
             
             addCoreRenderers(info, 'phenotype', id);
@@ -3222,9 +3545,12 @@ app.get('/phenotype/:id.:fmt?',
 
             var output = pup_tent.render('phenotype.mustache', info,
                                          'monarch_base.mustache');
-            return response.html(output);
-            return res;
- });
+            return web.wrapHTML(output);
+    }
+);
+
+
+
 
 //PHENOTYPE - Sub-pages
 //Example: /phenotype/MP_0000854/phenotype_associations.json
@@ -3247,176 +3573,175 @@ app.get('/phenotype/:id/:section.:fmt?', function(request, id, section, fmt) {
 });
 
 
-app.get('/disease/:id.:fmt?',
-        function(request, id, fmt){
-    
-        try {
-            engine.log("getting /disease/:id where id="+id);
-            
-            //Curify ID if needed
-            if (/_/.test(id)){
-                engine.log("ID contains underscore, replacing with : and redirecting");
-                var newID = id.replace("_",":");
-                return response.redirect(genURL('disease',newID));
-            }
+web.wrapRouteGet(app, '/disease/:id.:fmt?', '/disease/{id}', ['id', 'fmt'],
+    function(request, id, fmt){
+    engine.log("getting /disease/:id where id="+id + " fmt=" + fmt);
 
-            // Rendering.
-            var info = {};
-            info = engine.fetchClassInfo(id, {level:1});
-            
-            if (fmt != null) {
-                return formattedResults(info, fmt,request);
-            }
-            
-            if (info.label == null || info.id == info.label){
-                var redirect = redirectDiseasePage(id, info.equivalentNodes);
-                if (redirect){
-                    return redirect;
-                }
-            }
-                        
-            addCoreRenderers(info, 'disease', id);
-                        
-            addGolrStaticFiles(info);
-            info.pup_tent_css_libraries.push("/monarch-main.css");
-            info.pup_tent_css_libraries.push("/monarch-specific.css");
-            
-            //Load variables for client side tables
-            var phenotype_filter = [{ field: 'object_category', value: 'phenotype' }];
-            addGolrTable(info, "subject_closure", id, 'phenotypes-table', phenotype_filter, 'disease_phenotype','#phenotypes');
-            info.phenotypeNum = engine.fetchAssociationCount(id, 'subject_closure', phenotype_filter);
-            
-            var gene_filter = [
-                               { field: 'subject_category', value: 'gene' },
-                               { field: 'object_category', value: 'disease' }
-            ];
-            addGolrTable(info, "object_closure", id, 'gene-table', gene_filter, 'gene_disease','#genes');
-            info.geneNum = engine.fetchAssociationCount(id, 'object_closure', gene_filter);
-            
-            var genotype_filter = [{ field: 'object_category', value: 'genotype' }];
-            addGolrTable(info, "subject_closure", id, 'genotype-table', genotype_filter, 'disease_genotype',"#genotypes");
-            info.genotypeNum = engine.fetchAssociationCount(id, 'subject_closure', genotype_filter);
-            
-            var model_filter = [{ field: 'subject_category', value: 'model' }];
-            addGolrTable(info, "object_closure", id, 'model-table', model_filter, 'model_disease','#models');
-            info.modelNum = engine.fetchAssociationCount(id, 'object_closure', model_filter);
-            
-            var variant_filter = [{ field: 'subject_category', value: 'variant' }];
-            addGolrTable(info, "object_closure", id, 'variant-table', variant_filter, 'variant_disease','#variants');
-            info.variantNum = engine.fetchAssociationCount(id, 'object_closure', variant_filter);
-            
-            var pathway_filter = [{ field: 'object_category', value: 'pathway' }];
-            addGolrTable(info, "subject_closure", id, 'pathway-table', pathway_filter, 'disease_pathway','#pathways');
-            info.pathwayNum = engine.fetchAssociationCount(id, 'subject_closure', pathway_filter);
-            
-            // Phenogrid
-            addPhenogridFiles(info);
-            
-            // Add templates
-            info.includes.phenotype_anchor = addPhenotypeAnchor(info);
-            info.includes.phenotype_table = addPhenotypeTable(info);
-            
-            // Add gene table
-            info.includes.gene_anchor = addGeneAnchor(info);
-            info.includes.gene_table = addGeneTable();
-            
-            // Add genotype table
-            info.includes.genotype_anchor = addGenotypeAnchor(info);
-            info.includes.genotype_table = addGenotypeTable();
-            
-            // Add model table
-            info.includes.model_anchor = addModelAnchor(info);
-            info.includes.model_table = addModelTable();
-            
-            // Add variant table
-            info.includes.variant_anchor = addVariantAnchor(info);
-            info.includes.variant_table = addVariantTable();
-            
-            // Add pathway table
-            info.includes.pathway_anchor = addPathwayAnchor(info);
-            info.includes.pathway_table = addPathwayTable();
+    //Curify ID if needed
+    if (/_/.test(id)){
+        engine.log("ID contains underscore, replacing with : and redirecting");
+        var newID = id.replace("_",":");
+        return web.wrapRedirect(genURL('disease',newID));
+    }
 
-            info.title = 'Monarch Disease: '+info.label+' ('+ info.id+')';
+    // Rendering.
+    var info = {};
+    info = engine.fetchClassInfo(id, {level:1});
 
-            info.primary_xref = function() {return genExternalHref('source',{id : id})};
-        
-            if (typeof info.synonyms != 'undefined'){
-                info.aka = info.synonyms.join(", ");
-            }
-            
-            info.xrefs = function() {
-                if (info.database_cross_reference != null) {
-                    return info.database_cross_reference.map(function(r) { return genExternalHref('source',{id : r}) }).join(", ");
-                    //return info.database_cross_reference.join(", ");
-                }
-            };
-            info.altids = function() {
-                if (info.has_alternative_id != null) {
-                    return info.has_alternative_id.join(", ");
-                }
-            }
-            
-            //info.hasHeritability = function() {return checkExistence(info.heritability)};
-            //info.heritability = engine.unique(info.heritability.map(function(h) {return h.inheritance.label})).join(", "); 
+    if (fmt != null) {
+        return formattedResults(info, fmt,request);
+    }
 
-            // variables checking existence of data in sections
-            info.hasDef = function() {return checkExistence(info.definitions)};
-            info.hasComment = function() {return checkExistence(info.comment)};
-            info.hasAka = function() {return checkExistence(info.synonyms)};
-            info.hasXrefs = function() {return checkExistence(info.database_cross_reference)};
-            info.hasPhenotypes = info.phenotypeNum;
-            if (info.phenotypeNum > 10000){
-                info.hasPhenotypes = false;
-            }
-            info.includes.phenogrid_anchor = Mustache.to_html(getTemplate('phenogrid-anchor'), info);
-            
-            var output;
-            //Launch function for annotation score
-            if (info.isLeafNode){
-                info.pup_tent_js_variables.push({name:'globalID',value:id});
-                info.monarch_launchable.push('getAnnotationScore(globalID)');
-                if (info.hasPhenotypes){
-                    info.pup_tent_js_libraries.push("/phenogridloader-no-species.js");
-                    info.monarch_launchable.push('loadPhenogrid()');
-                }
-                output = pup_tent.render('disease.mustache', info,
-                    'monarch_base.mustache');
-            } else {
-                if (info.hasPhenotypes){
-                    info.pup_tent_js_libraries.push("/phenogridloader-onclick.js");
-                    info.monarch_launchable.push('loadPhenogrid()');
-                }
-                output = pup_tent.render('disease-non-leaf.mustache', info,
-                    'monarch_base.mustache');
-            }
-
-            return response.html(output);
-            
-        } catch(err) {
-            return errorResponse(err);
+    if (info.label == null || info.id == info.label){
+        var redirect = redirectDiseasePage(id, info.equivalentNodes);
+        if (redirect){
+            return redirect;
         }
- });
+    }
+
+    addCoreRenderers(info, 'disease', id);
+
+    addGolrStaticFiles(info);
+    info.pup_tent_css_libraries.push("/monarch-main.css");
+    info.pup_tent_css_libraries.push("/monarch-specific.css");
+
+    //Load variables for client side tables
+    var phenotype_filter = [{ field: 'object_category', value: 'phenotype' }];
+    addGolrTable(info, "subject_closure", id, 'phenotypes-table', phenotype_filter, 'disease_phenotype','#phenotypes');
+    info.phenotypeNum = engine.fetchAssociationCount(id, 'subject_closure', phenotype_filter);
+
+    var gene_filter = [
+                       { field: 'subject_category', value: 'gene' },
+                       { field: 'object_category', value: 'disease' }
+    ];
+    addGolrTable(info, "object_closure", id, 'gene-table', gene_filter, 'gene_disease','#genes');
+    info.geneNum = engine.fetchAssociationCount(id, 'object_closure', gene_filter);
+
+    var genotype_filter = [{ field: 'object_category', value: 'genotype' }];
+    addGolrTable(info, "subject_closure", id, 'genotype-table', genotype_filter, 'disease_genotype',"#genotypes");
+    info.genotypeNum = engine.fetchAssociationCount(id, 'subject_closure', genotype_filter);
+
+    var model_filter = [{ field: 'subject_category', value: 'model' }];
+    addGolrTable(info, "object_closure", id, 'model-table', model_filter, 'model_disease','#models');
+    info.modelNum = engine.fetchAssociationCount(id, 'object_closure', model_filter);
+
+    var variant_filter = [{ field: 'subject_category', value: 'variant' }];
+    addGolrTable(info, "object_closure", id, 'variant-table', variant_filter, 'variant_disease','#variants');
+    info.variantNum = engine.fetchAssociationCount(id, 'object_closure', variant_filter);
+
+    var pathway_filter = [{ field: 'object_category', value: 'pathway' }];
+    addGolrTable(info, "subject_closure", id, 'pathway-table', pathway_filter, 'disease_pathway','#pathways');
+    info.pathwayNum = engine.fetchAssociationCount(id, 'subject_closure', pathway_filter);
+
+    // Phenogrid
+    addPhenogridFiles(info);
+
+    // Add templates
+    info.includes.phenotype_anchor = addPhenotypeAnchor(info);
+    info.includes.phenotype_table = addPhenotypeTable(info);
+
+    // Add gene table
+    info.includes.gene_anchor = addGeneAnchor(info);
+    info.includes.gene_table = addGeneTable();
+
+    // Add genotype table
+    info.includes.genotype_anchor = addGenotypeAnchor(info);
+    info.includes.genotype_table = addGenotypeTable();
+
+    // Add model table
+    info.includes.model_anchor = addModelAnchor(info);
+    info.includes.model_table = addModelTable();
+
+    // Add variant table
+    info.includes.variant_anchor = addVariantAnchor(info);
+    info.includes.variant_table = addVariantTable();
+
+    // Add pathway table
+    info.includes.pathway_anchor = addPathwayAnchor(info);
+    info.includes.pathway_table = addPathwayTable();
+
+    info.title = 'Monarch Disease: '+info.label+' ('+ info.id+')';
+
+    info.primary_xref = function() {return genExternalHref('source',{id : id})};
+
+    if (typeof info.synonyms != 'undefined'){
+        info.aka = info.synonyms.join(", ");
+    }
+
+    info.xrefs = function() {
+        if (info.database_cross_reference != null) {
+            return info.database_cross_reference.map(function(r) { return genExternalHref('source',{id : r}) }).join(", ");
+            //return info.database_cross_reference.join(", ");
+        }
+    };
+    info.altids = function() {
+        if (info.has_alternative_id != null) {
+            return info.has_alternative_id.join(", ");
+        }
+    }
+
+    //info.hasHeritability = function() {return checkExistence(info.heritability)};
+    //info.heritability = engine.unique(info.heritability.map(function(h) {return h.inheritance.label})).join(", ");
+
+    // variables checking existence of data in sections
+    info.hasDef = function() {return checkExistence(info.definitions)};
+    info.hasComment = function() {return checkExistence(info.comment)};
+    info.hasAka = function() {return checkExistence(info.synonyms)};
+    info.hasXrefs = function() {return checkExistence(info.database_cross_reference)};
+    info.hasPhenotypes = info.phenotypeNum;
+    if (info.phenotypeNum > 10000){
+        info.hasPhenotypes = false;
+    }
+    info.includes.phenogrid_anchor = Mustache.to_html(getTemplate('phenogrid-anchor'), info);
+
+    var output;
+    //Launch function for annotation score
+    if (info.isLeafNode){
+        info.pup_tent_js_variables.push({name:'globalID',value:id});
+        info.monarch_launchable.push('getAnnotationScore(globalID)');
+        if (info.hasPhenotypes){
+            info.pup_tent_js_libraries.push("/phenogridloader-no-species.js");
+            info.monarch_launchable.push('loadPhenogrid()');
+        }
+        output = pup_tent.render('disease.mustache', info,
+            'monarch_base.mustache');
+    } else {
+        if (info.hasPhenotypes){
+            info.pup_tent_js_libraries.push("/phenogridloader-onclick.js");
+            info.monarch_launchable.push('loadPhenogrid()');
+        }
+        output = pup_tent.render('disease-non-leaf.mustache', info,
+            'monarch_base.mustache');
+    }
+
+    return web.wrapHTML(output);
+}
+);
+
 
 //DISEASE - Sub-pages
 //Example: /disease/DOID_12798/phenotype_associations.json
 //Currently only works for json or rdf output
-app.get('/disease/:id/:section.:fmt?', function(request, id, section, fmt) {
 
-    var info = engine.fetchCoreDiseaseInfo(id);
+web.wrapRouteGet(app, '/disease/:id/:section.:fmt?', '/disease/{id}/{section}.{fmt?}', ['id', 'section', 'fmt'],
+    function(request, id, section, fmt){
+        var info = engine.fetchCoreDiseaseInfo(id);
 
-    var sectionInfo =
-         { id: "obo:"+id }; // <-- TODO - unify ID/URI strategy
-    sectionInfo[section] = info[section];
-    engine.addJsonLdContext(sectionInfo);
+        var sectionInfo =
+             { id: "obo:"+id }; // <-- TODO - unify ID/URI strategy
+        sectionInfo[section] = info[section];
+        engine.addJsonLdContext(sectionInfo);
 
-    if (fmt != null) {
-        return formattedResults(sectionInfo, fmt,request);
-    } else {
-        return response.error("plain HTML does not work for page sections. Please append .json or .rdf to URL");
+        if (fmt != null) {
+            return formattedResults(sectionInfo, fmt, request);
+        } else {
+            return formattedError("plain HTML does not work for page sections. Please append .json or .rdf to URL");
+        }
     }
-});
+);
 
-var fetchFeatureSection = function(request, id, section, fmt) {
+
+function fetchFeatureSection(request, id, section, fmt) {
     console.log(request + ' ' + id + ' ' + section + ' ' + fmt);
     var info = engine.fetchCoreGeneInfo(id);
 
@@ -3428,18 +3753,19 @@ var fetchFeatureSection = function(request, id, section, fmt) {
     if (fmt != null) {
         return formattedResults(sectionInfo, fmt,request);
     } else {
-        return response.error("plain HTML does not work for page sections. Please append .json or .rdf to URL");
+        return formattedError("plain HTML does not work for page sections. Please append .json or .rdf to URL");
     }
 }
 
-var fetchFeaturePage = function(request, id, fmt) {
+web.wrapRouteGet(app, '/gene/:id.:fmt?', '/gene/{id}', ['id'],
+    function(request, id, fmt) {
     try {
         
         //Curify ID if needed
         if (/_/.test(id)){
             engine.log("ID contains underscore, replacing with : and redirecting");
             var newID = id.replace("_",":");
-            return response.redirect(genURL('gene',newID));
+            return web.wrapRedirect(genURL('gene',newID));
         }
 
         // Rendering.
@@ -3573,13 +3899,14 @@ var fetchFeaturePage = function(request, id, fmt) {
         
         var output = pup_tent.render('gene.mustache', info,
                  'monarch_base.mustache');
-        return response.html(output);
-        
+        return web.wrapHTML(output);
+
     } catch(err) {
         return errorResponse(err);
     }
     
 }
+);
 
 var redirectGenePage = function(id, equivalentNodes) {
    var prefix = id.replace(/(\w+):([\w\d]+)/, "$1");
@@ -3594,23 +3921,23 @@ var redirectGenePage = function(id, equivalentNodes) {
    //Preference when redirecting MGI,ZFIN > NCBIGene > OMIM > ENSEMBL
    if (prefix != 'MGI' && 'MGI' in nodeMap && nodeMap['MGI'].lbl != null){
        engine.log("Redirecting to id: "+ nodeMap['MGI'].id);
-       return response.redirect(genURL('gene',nodeMap['MGI'].id));
+       return web.wrapRedirect(genURL('gene',nodeMap['MGI'].id));
     
    } else if (prefix != 'ZFIN' && 'ZFIN' in nodeMap && nodeMap['ZFIN'].lbl != null){
        engine.log("Redirecting to id: "+ nodeMap['ZFIN'].id);
-       return response.redirect(genURL('gene',nodeMap['ZFIN'].id)); 
+       return web.wrapRedirect(genURL('gene',nodeMap['ZFIN'].id)); 
        
    } else if (prefix != 'NCBIGene' && 'NCBIGene' in nodeMap && nodeMap['NCBIGene'].lbl != null){
        engine.log("Redirecting to id: "+ nodeMap['NCBIGene'].id);
-       return response.redirect(genURL('gene',nodeMap['NCBIGene'].id));
+       return web.wrapRedirect(genURL('gene',nodeMap['NCBIGene'].id));
        
    } else if (prefix != 'OMIM' && 'OMIM' in nodeMap && nodeMap['OMIM'].lbl != null){
        engine.log("Redirecting to id: "+ nodeMap['OMIM'].id);
-       return response.redirect(genURL('gene',nodeMap['OMIM'].id));
+       return web.wrapRedirect(genURL('gene',nodeMap['OMIM'].id));
        
    } else if (prefix != 'ENSEMBL' && 'ENSEMBL' in nodeMap && nodeMap['ENSEMBL'].lbl != null){
        engine.log("Redirecting to id: "+ nodeMap['ENSEMBL'].id);
-       return response.redirect(genURL('gene',nodeMap['ENSEMBL'].id));  
+       return web.wrapRedirect(genURL('gene',nodeMap['ENSEMBL'].id));  
    } 
 
 };
@@ -3627,16 +3954,16 @@ var redirectDiseasePage = function(id, equivalentNodes) {
     
     //Preference when redirecting OMIM > DOID > Orphanet > MESH
     if (prefix != 'OMIM' && 'OMIM' in nodeMap && nodeMap['OMIM'].lbl != null){
-        return response.redirect(genURL('disease',nodeMap['OMIM'].id));
+        return web.wrapRedirect(genURL('disease',nodeMap['OMIM'].id));
      
     } else if (prefix != 'DOID' && 'DOID' in nodeMap && nodeMap['DOID'].lbl != null){
-        return response.redirect(genURL('disease',nodeMap['DOID'].id)); 
+        return web.wrapRedirect(genURL('disease',nodeMap['DOID'].id)); 
         
     } else if (prefix != 'Orphanet' && 'Orphanet' in nodeMap && nodeMap['Orphanet'].lbl != null){
-        return response.redirect(genURL('disease',nodeMap['Orphanet'].id));
+        return web.wrapRedirect(genURL('disease',nodeMap['Orphanet'].id));
         
     } else if (prefix != 'MESH' && 'MESH' in nodeMap && nodeMap['MESH'].lbl != null){
-        return response.redirect(genURL('disease',nodeMap['MESH'].id));  
+        return web.wrapRedirect(genURL('disease',nodeMap['MESH'].id));  
     } 
 };
 
@@ -3778,17 +4105,16 @@ var fetchVariantPage = function(request, id, fmt) {
 }
 
 
-app.get('/gene/:id.:fmt?', fetchFeaturePage);
 app.get('/variant/:id', fetchVariantPage);
 
 //Sequence Feature - Sub-pages
 //Example: /gene/NCIBGene:12166/phenotype_associations.json
 //Currently only works for json or rdf output
-app.get('/gene/:id/:section.:fmt?',fetchFeatureSection);
-app.get('/variant/:id/:section.:fmt?',fetchFeatureSection);
-app.get('/genotype/:id/:section.:fmt?', fetchFeatureSection);
-app.get('/model/:id/:section.:fmt?', fetchFeatureSection);
 
+web.wrapRouteGet(app, '/gene/:id/:section.:fmt?', '/gene/{id}/{section}.{fmt?}', ['id', 'section', 'fmt'], fetchFeatureSection);
+web.wrapRouteGet(app, '/variant/:id/:section.:fmt?', '/variant/{id}/{section}.{fmt?}', ['id', 'section', 'fmt'], fetchFeatureSection);
+web.wrapRouteGet(app, '/genotype/:id/:section.:fmt?', '/genotype/{id}/{section}.{fmt?}', ['id', 'section', 'fmt'], fetchFeatureSection);
+web.wrapRouteGet(app, '/model/:id/:section.:fmt?', '/model/{id}/{section}.{fmt?}', ['id', 'section', 'fmt'], fetchFeatureSection);
 
 app.get('/labs/case/:id/phenotype_list.:fmt?', function(request, id, fmt){
     var info = {};
@@ -3853,7 +4179,7 @@ app.get('/association/:id.:fmt?',
             if (/_/.test(id)){
                 engine.log("ID contains underscore, replacing with : and redirecting");
                 var newID = id.replace("_",":");
-                return response.redirect(genURL('association',newID));
+                return web.wrapRedirect(genURL('association',newID));
             }
             
             // Rendering.
@@ -4060,9 +4386,9 @@ app.get('/labs/jbrowse/*', function(request){
     //var res =  response.html('<em>' + path + ': not found</em>'); // default err
     //def ctype = _decide_content_type(path)
     //var res =  response.html('<em>' + fs.Path(mapped_path).absolute()+ ': not found</em>'); // default err
-    //if( fs.exists(path) ){
+    //if( env.fs_existsSync(path) ){
     //    res = _return_mapped_content(path);
-    if( fs.exists(mapped_path) ){
+    if( env.fs_existsSync(mapped_path) ){
         var res = _return_mapped_content(mapped_path);
         return res ;
     }
@@ -4105,12 +4431,13 @@ app.get('/*',function(request) {
 });
 
 
-// INITIALIZATION
-// Can set port from command line. E.g. --port 8080
-if (require.main == module) {
-   require('ringo/httpserver').main(module.id);
+if (env.isRingoJS()) {
+    // INITIALIZATION
+    // Can set port from command line. E.g. --port 8080
+    if (require.main == module) {
+       require('ringo/httpserver').main(module.id);
+    }
 }
-
 
 //TODO Delete
 app.get('/labs/gene/:id.:fmt?', function(request, id, fmt) {
@@ -4119,7 +4446,7 @@ app.get('/labs/gene/:id.:fmt?', function(request, id, fmt) {
     var mappedID = getGeneMapping(id);
     if (typeof mappedID != 'undefined' && mappedID != id){
         engine.log("found updated ID, redirecting to: "+mappedID);
-        return response.redirect(genURL('gene',mappedID));
+        return web.wrapRedirect(genURL('gene',mappedID));
     }
 
     var info;
@@ -4212,8 +4539,9 @@ app.get('/labs/gene/:id.:fmt?', function(request, id, fmt) {
     return response.html(output);
     //return response.html(Mustache.to_html(getTemplate('gene'), info));
 });
- 
- app.post('/analyze/:datatype.:fmt?', function(request, datatype, fmt) {
+
+
+function analyzeByDatatypePostHandler(request, datatype, fmt) {
      
      var info = {};
      //Some hardcoded things for mustache
@@ -4243,12 +4571,12 @@ app.get('/labs/gene/:id.:fmt?', function(request, id, fmt) {
          // File hit hard size limit when writing but for some reason
          // wasn't caught in the content-length
          if (request.params.hit_limit){
-             fs.remove(fileUpload.tempfile);
+             env.fs_unlinkSync(fileUpload.tempfile);
              info.doesFileExceedMax = true;
              info.isFileError = true;
          } else {
-             user_request = fs.read(fileUpload.tempfile);
-             fs.remove(fileUpload.tempfile);
+             user_request = env.fs_readFileSync(fileUpload.tempfile);
+             env.fs_unlinkSync(fileUpload.tempfile);
              info.hasInputItems = true;
          }
      } else if (typeof request.params.user_results != 'undefined') {
@@ -4298,10 +4626,10 @@ app.get('/labs/gene/:id.:fmt?', function(request, id, fmt) {
      info.title = 'Monarch Analysis';
 
      var output = pup_tent.render('analyze.mustache',info,'monarch_base.mustache');
-     return response.html(output);
- });
- 
- app.get('/analyze/:datatype.:fmt?', function(request, datatype, fmt) {
+     return web.wrapHTML(output);
+}
+
+function analyzeByDatatypeGetHandler(request, datatype, fmt) {
      var target = request.params.target;
      var species = request.params.target_species;
      var mode = request.params.mode;
@@ -4449,9 +4777,12 @@ app.get('/labs/gene/:id.:fmt?', function(request, id, fmt) {
      }
 
      var output = pup_tent.render('analyze.mustache',info,'monarch_base.mustache');
-     return response.html(output);
- });
- 
+     return web.wrapHTML(output);
+}
+
+web.wrapRoutePost(app, '/analyze/:datatype.:fmt?', '/analyze/{datatype}', ['datatype', 'fmt'], analyzeByDatatypePostHandler);
+web.wrapRouteGet(app, '/analyze/:datatype.:fmt?', '/analyze/{datatype}', ['datatype', 'fmt'], analyzeByDatatypeGetHandler);
+
 
  app.get('/labs/classenrichment', function(request) {
      var info = {};
@@ -4566,13 +4897,14 @@ app.get('/labs/gene/:id.:fmt?', function(request, id, fmt) {
                      headers.push(line);
                  }
              });
-             for each (var header in headers) {
-                 if (strings.startsWith(header.toLowerCase(), "content-disposition:")) {
-                     data.name = getMimeParameter(header, "name");
-                     data.filename = getMimeParameter(header, "filename");
-                 } else if (strings.startsWith(header.toLowerCase(), "content-type:")) {
-                     data.contentType = header.substring(13).trim();
-                 }
+             for (var headerkey in headers) {
+                var header = headers[headerkey];
+                if (strings.startsWith(header.toLowerCase(), "content-disposition:")) {
+                  data.name = getMimeParameter(header, "name");
+                  data.filename = getMimeParameter(header, "filename");
+                } else if (strings.startsWith(header.toLowerCase(), "content-type:")) {
+                  data.contentType = header.substring(13).trim();
+                }
              }
              // move position after the empty line that separates headers from body
              position = b + EMPTY_LINE.length;
@@ -4678,7 +5010,7 @@ app.get('/labs/gene/:id.:fmt?', function(request, id, fmt) {
              if (/_/.test(id)){
                  engine.log("ID contains underscore, replacing with : and redirecting");
                  var newID = id.replace("_",":");
-                 return response.redirect(genURL('phenotype',newID));
+                 return web.wrapRedirect(genURL('phenotype',newID));
              }
 
              // Rendering.

--- a/lib/monarch/web/webapp_launcher.js
+++ b/lib/monarch/web/webapp_launcher.js
@@ -1,6 +1,12 @@
-// this is a temporary state of affairs - will move to CommonJS and this will no longer be necessary
+var env = require('../serverenv.js');
 
-load('lib/monarch/api.js');
-load('lib/monarch/web/widgets.js');
-load('lib/monarch/web/webapp.js');
-
+if (env.isRingoJS()) {
+	load('lib/monarch/api.js');
+	load('lib/monarch/web/widgets.js');
+	load('lib/monarch/web/webapp.js');
+}
+else {
+	eval(env.fs_readFileSync('lib/monarch/api.js')+'');
+	eval(env.fs_readFileSync('lib/monarch/web/widgets.js')+'');
+	eval(env.fs_readFileSync('lib/monarch/web/webapp.js')+'');
+}

--- a/lib/monarch/web/webapp_launcher_node.js
+++ b/lib/monarch/web/webapp_launcher_node.js
@@ -1,0 +1,12 @@
+var env = require('../serverenv.js');
+
+var bbop = require('bbop');
+if (typeof bbop == 'undefined') { var bbop = {};}
+if (typeof bbop.monarch == 'undefined') { bbop.monarch = {};}
+//see: https://docs.google.com/document/d/1ZxGuuvyvMmHVWQ7rIleIRkmbiDTNNP27eAHhxyFWHok/edit#
+
+console.log("This is a development server1");
+
+bbop.monarch.defaultConfig = JSON.parse(env.fs_readFileSync("conf/server_config_dev.json"));
+bbop.monarch.golrConfig = JSON.parse(env.fs_readFileSync("conf/golr-conf.json"));
+eval(env.fs_readFileSync('lib/monarch/web/webapp_launcher.js')+'');

--- a/lib/monarch/web/webenv.js
+++ b/lib/monarch/web/webenv.js
@@ -1,0 +1,225 @@
+// Utility function to determine NodeJS vs RingoJS runtime environment
+function isRingoJS() {
+  return (typeof(org) != 'undefined' && typeof(org.ringo) != 'undefined' );
+}
+
+//
+// Abstractions over the Ringo/stick vs Node/HAPI http server interfaces.
+//
+// The goal:
+//     Minimizing the changes to the existing RingoJS code base, specifically webapp.js, figure out a way
+//  to avoid code duplication and allow the web application to be served via RingoJS and stick as well as via
+//  NodeJS and HAPI.js.
+//
+// Challenges:
+//  Different route syntaxes: '/docs/:file' vs '/docs/{file}'
+//  Different route handler signatures. stick extracts values from URL path and makes them formal arguments
+//  to the handler. Hapi extracts values and places them into the request.params object.
+//  stick handlers write to the output by returning objects with .headers, .status, and .body fields; Hapi
+//  handlers write to output by invoking methods on the 'reply' object.
+//  stick handlers can invoke blocking operations, NodeJS handlers that block (without using Fibers or something)
+//  will result in an unresponsive webserver while blocked.
+//
+// Solution:
+// Basic idea is to adopt the RingoJS of returning an object from a route handler. The object (call it a Response
+// to distinguish it from the ringojs 'response' module) has the structure:
+//  {
+//      status: 200,    // HTTP status code
+//      headers: ['Content-Type', 'text/html'],
+//      body: ["Body Text Here"]
+//  }
+//
+//  Ringo uses static methods on the require('response') module to build these Response structures. For example, the above example
+//  may be built (in Ringo) with:
+//      response.html("Body Text Here");
+//
+//  In Hapi, we must build the Response object explicitly. In order to have fewer conditionals, there are
+//  wrappers provided below, wrapHTML() and wrapJSON(), which either invoke the Ringo response.html() or
+//  response.json() methods, or construct the response object explicitly in Hapi:
+//      wrapHTML("Body Text Here")
+//
+// EXAMPLE:
+//  The following example shows how we can define a route using both stick and hapi syntax and still
+//  enable a single handler definition to be used:
+//
+//    web.wrapRouteGet(app, '/page/:page', '/page/{page}', ['page'],
+//         function(request, page) {
+//             var info = {};
+//             addCoreRenderers(info);
+
+//             if ((page !== 'software')){
+//                 info.pup_tent_css_libraries.push("/tour.css");
+//             } else {
+//                 info.pup_tent_css_libraries.push("/monarch-main.css");
+//             }
+
+//             var output = pup_tent.render(page+'.mustache',info);
+//             return web.wrapHTML(output);
+//         }
+//    );
+//
+//
+
+
+if (isRingoJS()) {
+    var response = require('ringo/jsgi/response');
+
+    function wrapRedirect(uri) {
+        return response.redirect(uri);
+    }
+
+    function wrapResponse(request, reply, output) {
+        return output;
+    }
+
+    function wrapHTML(output) {
+        return response.html(output);
+    }
+
+    function wrapJSON(output) {
+        return response.json(output);
+    }
+
+    function wrapTEXT(output) {
+        return {
+            status: 200,
+            headers: {"Content-Type": 'text/plain'},
+            body: [output]
+        };
+    }
+
+    function wrapBinary(output, ctype) {
+        return {
+            body: [output],
+            headers: {'Content-Type': ctype},
+            status: 200
+        };
+    }
+
+    function wrapRouteGet(app, ringoPath, hapiPath, props, commonHandler) {
+        var ringoResponse = app.get(ringoPath, commonHandler);
+        return wrapResponse(ringoResponse);
+    }
+
+    function wrapRoutePost(app, ringoPath, hapiPath, props, commonHandler) {
+        var ringoResponse = app.post(ringoPath, commonHandler);
+        return wrapResponse(ringoResponse);
+    }
+}
+else {
+    var WaitFor = require('wait.for');
+
+    function wrapRedirect(uri) {
+        var result = {
+                status: 302,
+                headers: {},    // "Content-Type": 'text/html'},
+                body: [],
+                uri: uri
+            };
+
+        return result;
+    }
+
+    function wrapResponse(request, reply, output) {
+        var response = reply(output.body);
+        var ctype = output.headers['Content-Type'];
+        if (ctype != 'text/html') {
+            response.type(ctype);
+        }
+        if (output.status === 302) {
+            response.redirect(output.uri);
+        }
+        return output;
+    }
+
+    function wrapHTML(output) {
+        var result = {
+                status: 200,
+                headers: {"Content-Type": 'text/html'},
+                body: output
+            };
+
+        return result;
+    }
+
+    function wrapTEXT(output) {
+        return {
+            status: 200,
+            headers: {"Content-Type": 'text/plain'},
+            body: output
+        };
+    }
+
+    function wrapBinary(output, ctype) {
+        return {
+            body: output,
+            headers: {'Content-Type': ctype},
+            status: 200
+        };
+    }
+
+    function wrapJSON(output) {
+        var result = {
+                status: 200,
+                headers: {"Content-Type": 'application/json'},
+                body: output
+            };
+
+        return result;
+    }
+
+    function wrapRouteGet(app, ringoPath, hapiPath, props, commonHandler) {
+        var that = this;
+        function wrappedHandler(request, reply) {
+            WaitFor.launchFiber(
+                function () {
+                    var     vals = [request];
+                    for (var propIndex in props) {
+                        vals.push(request.params[props[propIndex]]);
+                    }
+
+                    var output = commonHandler.apply(that, vals);
+                    wrapResponse(request, reply, output);
+                });
+        }
+
+        app.route({
+            method: 'GET',
+            path: hapiPath,
+            handler: wrappedHandler
+        });
+    }
+
+    function wrapRoutePost(app, ringoPath, hapiPath, props, commonHandler) {
+        var that = this;
+        function wrappedHandler(request, reply) {
+            WaitFor.launchFiber(
+                function () {
+                    var     vals = [request];
+                    for (var propIndex in props) {
+                        vals.push(request.params[props[propIndex]]);
+                    }
+
+                    var output = commonHandler.apply(that, vals);
+                    wrapResponse(request, reply, output);
+                });
+        }
+
+        app.route({
+            method: 'POST',
+            path: hapiPath,
+            handler: wrappedHandler
+        });
+    }
+
+}
+
+
+exports.wrapRedirect = wrapRedirect;
+exports.wrapResponse = wrapResponse;
+exports.wrapHTML = wrapHTML;
+exports.wrapTEXT = wrapTEXT;
+exports.wrapBinary = wrapBinary;
+exports.wrapJSON = wrapJSON;
+exports.wrapRouteGet = wrapRouteGet;
+exports.wrapRoutePost = wrapRoutePost;

--- a/lib/monarch/web/widgets.js
+++ b/lib/monarch/web/widgets.js
@@ -1,4 +1,4 @@
-var {convChars}  =  require("./utils");
+var convChars =  require("./utils").convChars;
 
 // GENERIC
 function genTable(spec, rows) {

--- a/modules/pup-tent/pup-tent.js
+++ b/modules/pup-tent/pup-tent.js
@@ -275,7 +275,7 @@ module.exports = function(search_path_list, filename_list){
 		 each(files,
 		      function(file){
 			  // Get only files, not directories.
-			  //console.log('found file: ' + file);
+			  //console.log('found file: ' + file + '      ' + loc + '/' + file);
 			  var full_file = loc + '/' + file;
 			  _check_and_save(full_file);
 		      });

--- a/node-server.sh
+++ b/node-server.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+echo starting NodeJS server
+NODE_PATH=./lib/monarch node lib/monarch/web/webapp_launcher_node.js

--- a/package.json
+++ b/package.json
@@ -17,12 +17,27 @@
     "npm": ">= 2.7.4"
   },
   "dependencies": {
+    "bbop": "^2.3.2",
+    "binary": "^0.3.0",
+    "core-util-is": "^1.0.1",
+    "events": "^1.0.2",
+    "hapi": "^8.8.0",
+    "isarray": "0.0.1",
+    "lodash": "^3.10.1",
+    "lodash._isiterateecall": "^3.0.9",
+    "mustache": "^2.1.2",
     "phenogrid": "git+https://github.com/monarch-initiative/phenogrid.git#release_2015-08-06",
-    "underscore": "1.8.3"
+    "request": "^2.60.0",
+    "sax": "^1.1.1",
+    "underscore": "1.8.3",
+    "wait.for": "^0.6.6",
+    "xml2js": "^0.4.10",
+    "xmlbuilder": "^2.6.4"
   },
   "devDependencies": {
     "chai": "^2.3.0",
     "del": "^1.1.1",
+    "glob": "^5.0.14",
     "gulp": "^3.9.0",
     "gulp-bump": "^0.3.0",
     "gulp-git": "^1.2.3",

--- a/start-server.sh
+++ b/start-server.sh
@@ -16,5 +16,5 @@ if [ $PORT ]
    MARGS="--port 8080"
 fi
 echo starting server
-export RINGO_MODULE_PATH=./modules/:$RINGO_MODULE_PATH
+export RINGO_MODULE_PATH=./modules/:./node_modules:./lib/monarch:$RINGO_MODULE_PATH
 tools/ringo lib/monarch/web/webapp_launcher_$RUNENV.js $MARGS

--- a/templates/annotate.mustache
+++ b/templates/annotate.mustache
@@ -51,7 +51,7 @@
                 {{^hasResults}}
                     <div id="query" class="first category">
                 {{/hasResults}}
-                    <form role="form" action="/annotate/text/" method="GET">
+                    <form role="form" action="/annotate/text" method="GET">
                         <p>Enter a phrase, piece of text, or abstract:</p>
                         <textarea cols="80" rows="10" id="annotate_auto_target" name="q">
 {{#query}}

--- a/templates/navbar.mustache
+++ b/templates/navbar.mustache
@@ -21,10 +21,10 @@
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown">
                         <i class="icon-th-large"></i>Browse <b class="caret"></b></a>
                     <ul class="dropdown-menu">
-                        <li><a href="/disease/">Diseases</a></li>
-                        <li><a href="/phenotype/">Phenotypes</a></li>
-                        <li><a href="/gene/">Genes</a></li>
-                        <li><a href="/model/">Models</a></li>
+                        <li><a href="/disease">Diseases</a></li>
+                        <li><a href="/phenotype">Phenotypes</a></li>
+                        <li><a href="/gene">Genes</a></li>
+                        <li><a href="/model">Models</a></li>
                         <!-- <li><a href="/literature/">Literature</a></li> -->
                     </ul>
                 </li>
@@ -32,9 +32,9 @@
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown">
                         <i class="icon-th-large"></i>Analyze <b class="caret"></b></a>
                     <ul class="dropdown-menu">
-                        <li><a href="/analyze/phenotypes/">Phenotypes</a></li>
+                        <li><a href="/analyze/phenotypes">Phenotypes</a></li>
                         <li><a href="/annotate/text">Annotate Text</a></li>
-                        <li><a href="/page/exomes/">Exomes</a></li>
+                        <li><a href="/page/exomes">Exomes</a></li>
                     </ul>
                 </li>
                 <li class="dropdown">

--- a/templates/page/services.mustache
+++ b/templates/page/services.mustache
@@ -82,7 +82,7 @@
                         <h3>Datatypes</h3>
                         The current list of datatypes:
                         <ul>
-                        <li><strong><a href="/disease/">/disease/</a>:id</strong> - Executes a call
+                        <li><strong><a href="/disease">/disease/</a>:id</strong> - Executes a call
                         to <a href="/docs/files/api-js.html#bbop.monarch.Engine.fetchDiseaseInfo">fetchDiseaseInfo(:id)</a>.
                         <br/>Examples:
                         <ul>

--- a/tests/behave/steps/selenium-basic.py
+++ b/tests/behave/steps/selenium-basic.py
@@ -26,7 +26,7 @@ def step_impl(context, page, id):
     #print(context.browser.title)
     context.browser.get(context.target + page)
     #time.sleep(30)
-    element = WebDriverWait(context.browser, 60).until(EC.presence_of_element_located((By.ID, id)))
+    element = WebDriverWait(context.browser, 200).until(EC.presence_of_element_located((By.ID, id)))
     # try:
     #     print(id)
     #     element = WebDriverWait(context.browser, 30).until(EC.presence_of_element_located((By.ID, id)))


### PR DESCRIPTION
Ready to Merge. Some regression may occur in the RingoJS implementation, but I will be ready to address this quickly (dan@quantumclay.com).

Here are the accumulated notes:
NodeJS (about 80% working).
Home Page works. Landing pages all work.
Autocomplete and search work.
Annotate works.
Cache and external data-fetching system works. Adds ability to manage
cache under NodeJS. Replaces eval with load for RingoJS to aid in Ringo
debugging. Ensures /phenogrid paths work for NodeJS. Other fixes.
Phenogrid and the per-disease page works. Replaces sync-request with
waitfor. Increases the time to wait for a 'slow page' in selenium.
Various cleanups and formatting. Add isarray to package.json because it
appears to be needed by wait.for Added core-util-is to package.json
because our production node version is too low (0.10)
Reduces verbosity of FETCHING to limit log size and allow TravisCI to
complete
Installed lodash._isiterateecall in an attempt to get Travis working
with a single package.json
Adds more uniform adaptor between RingoJS/NodeJS for wrapping routes,
requests, and responses. Gets the /phenotype/:id route working.
Remove debug statements. Generalize more routes. Fix /sources route.
Gets the /docs directory working.
factors out the ringo/node web server wrappers into webenv.js
converts more of the routes in webapp.js to be compatible with both
Ringo and Node
Adds POST wrapper. Wraps more routes. Autocomplete and annotate work in
NodeJS. Many more tests work in NodeJS.

To run with RingoJS:
        ./start-server.sh

To run with NodeJS:
    NODE_PATH=./lib/monarch node lib/monarch/web/webapp_launcher_node.js
or:
    ./node-server.sh
