### PR TITLE
Fixes the use of NodeJS request to be compatible with the ringo/request. Mostly this involved the use of the 'useQuerystring' option to ensure that parameters are encoded in form-url-encoded mode.

### DIFF
--- a/lib/monarch/api.js
+++ b/lib/monarch/api.js
@@ -1395,7 +1395,7 @@ bbop.monarch.Engine.prototype.getDiseaseAssocsFromOrthologs = function(gene) {
         if (gene.orthologs[i].organism == 'Homo sapiens'){
             var disObj = engine.fetchDiseaseGeneAssociations(gene.orthologs[i].ortholog.id,'gene');
             if (disObj){
-                disease_ortho_assocs = disObj.filter(function(d){
+                var disease_ortho_assocs = disObj.filter(function(d){
                     return d.gene.id === gene.orthologs[i].ortholog.id;});
                 disease_ortho_assocs = 
                     engine.collapseEquivalencyClass(
@@ -6618,24 +6618,24 @@ bbop.monarch.Engine.prototype.fetchUrlWithExchangeObject = function(url, params,
         }
     }
     else {
-        if (params && !_.isEmpty(params)) {
-            var querystring = require("querystring");
-            var uriparams = querystring.stringify(params);
-            url = url + '?' + uriparams;
-        };
+        if (method === 'post') {
+            var postOptions = {
+                uri: url,
+                form: params,
+                useQuerystring: true,
+                method: 'POST'
+            };
 
-        if (method == 'post') {
-            var res = WaitFor.for(AsyncRequest.post, url);
+            var res = WaitFor.for(AsyncRequest.post, postOptions);
         }
         else {
-            // For some reason, using the 'qs:' option results in array results being encoded weird.
-            //      "fq[0]":"subject_closure:\"DOID:0080001\"",
-            //      "fq[1]":"object_category:\"phenotype\"",
-            // instead of:
-            //  "fq":["subject_closure:\"DOID:0080001\"","object_category:\"phenotype\""],
-            //
+            var getOptions = {
+                url: url,
+                qs: params,
+                useQuerystring: true
+            }
 
-            var res = WaitFor.for(AsyncRequest.get, url);
+            var res = WaitFor.for(AsyncRequest.get, getOptions);
         }
 
         exchangeObj = {
@@ -6645,9 +6645,22 @@ bbop.monarch.Engine.prototype.fetchUrlWithExchangeObject = function(url, params,
     }
 
     timeDelta = Date.now() - timeDelta;
-
+    // var g = env.isRingoJS() ? global : this;
+    // if (g._timingRequestCount) {
+    //   g._timingRequestCount = g._timingRequestCount + 1;
+    //   g._timingRequestTime = g._timingRequestTime + timeDelta;
+    //   g._timingRequestLength = g._timingRequestLength + exchangeObj.content.length;
+    // }
+    // else {
+    //   g._timingRequestCount = 1;
+    //   g._timingRequestTime = timeDelta;
+    //   g._timingRequestLength = exchangeObj.content.length;
+    // }
     this.log("FETCHED status: " + exchangeObj.status + "  Length: " + exchangeObj.content.length + "  Time: " +
         timeDelta + "ms");
+        // "  Total #" + g._timingRequestCount +
+        // "  Total Time: " + g._timingRequestTime +
+        // "  Total Length: " + g._timingRequestLength);
 
     return exchangeObj;
 }


### PR DESCRIPTION
Fixes the use of NodeJS request to be compatible with the ringo/request. Mostly this involved the use of the 'useQuerystring' option to ensure that parameters are encoded in form-url-encoded mode.
