### PR TITLE
Fixes the use of NodeJS request to be compatible with the ringo/request.  Mostly this involved the use of the 'useQuerystring' option to ensure that parameters are encoded in form-url-encoded mode.  Removes use of getTemplate() in webapp and the explicit use of mustache in favor of calling puptent's render() method.  Deletes lots of dead code.

### DIFF
--- a/lib/monarch/api.js
+++ b/lib/monarch/api.js
@@ -1395,7 +1395,7 @@ bbop.monarch.Engine.prototype.getDiseaseAssocsFromOrthologs = function(gene) {
         if (gene.orthologs[i].organism == 'Homo sapiens'){
             var disObj = engine.fetchDiseaseGeneAssociations(gene.orthologs[i].ortholog.id,'gene');
             if (disObj){
-                disease_ortho_assocs = disObj.filter(function(d){
+                var disease_ortho_assocs = disObj.filter(function(d){
                     return d.gene.id === gene.orthologs[i].ortholog.id;});
                 disease_ortho_assocs = 
                     engine.collapseEquivalencyClass(
@@ -6618,24 +6618,24 @@ bbop.monarch.Engine.prototype.fetchUrlWithExchangeObject = function(url, params,
         }
     }
     else {
-        if (params && !_.isEmpty(params)) {
-            var querystring = require("querystring");
-            var uriparams = querystring.stringify(params);
-            url = url + '?' + uriparams;
-        };
+        if (method === 'post') {
+            var postOptions = {
+                uri: url,
+                form: params,
+                useQuerystring: true,
+                method: 'POST'
+            };
 
-        if (method == 'post') {
-            var res = WaitFor.for(AsyncRequest.post, url);
+            var res = WaitFor.for(AsyncRequest.post, postOptions);
         }
         else {
-            // For some reason, using the 'qs:' option results in array results being encoded weird.
-            //      "fq[0]":"subject_closure:\"DOID:0080001\"",
-            //      "fq[1]":"object_category:\"phenotype\"",
-            // instead of:
-            //  "fq":["subject_closure:\"DOID:0080001\"","object_category:\"phenotype\""],
-            //
+            var getOptions = {
+                url: url,
+                qs: params,
+                useQuerystring: true
+            }
 
-            var res = WaitFor.for(AsyncRequest.get, url);
+            var res = WaitFor.for(AsyncRequest.get, getOptions);
         }
 
         exchangeObj = {
@@ -6645,9 +6645,22 @@ bbop.monarch.Engine.prototype.fetchUrlWithExchangeObject = function(url, params,
     }
 
     timeDelta = Date.now() - timeDelta;
-
+    // var g = env.isRingoJS() ? global : this;
+    // if (g._timingRequestCount) {
+    //   g._timingRequestCount = g._timingRequestCount + 1;
+    //   g._timingRequestTime = g._timingRequestTime + timeDelta;
+    //   g._timingRequestLength = g._timingRequestLength + exchangeObj.content.length;
+    // }
+    // else {
+    //   g._timingRequestCount = 1;
+    //   g._timingRequestTime = timeDelta;
+    //   g._timingRequestLength = exchangeObj.content.length;
+    // }
     this.log("FETCHED status: " + exchangeObj.status + "  Length: " + exchangeObj.content.length + "  Time: " +
         timeDelta + "ms");
+        // "  Total #" + g._timingRequestCount +
+        // "  Total Time: " + g._timingRequestTime +
+        // "  Total Length: " + g._timingRequestLength);
 
     return exchangeObj;
 }
@@ -7547,7 +7560,7 @@ bbop.monarch.Engine.prototype.fetchCoreDiseaseInfo = function(id) {
             
         });
     }
-    
+
     return obj;
 }
 

--- a/lib/monarch/web/webapp.js
+++ b/lib/monarch/web/webapp.js
@@ -275,10 +275,14 @@ function _return_mapped_content(loc){
 
 // Add routes for all static cache items at top-level.
 pup_tent.cached_list().forEach(
-function(thing){
-    // This will skip cached templates.
+  function(thing) {
+    // This will skip cached templates and other files not intended to be
+    // sent to the client
+    var route_exclusion_re = /\.mustache$|\.json$/;
+
     var ctype = _decide_content_type(thing);
-    if( ctype !== null ){
+    if( ctype !== null && !route_exclusion_re.test(thing)) {
+        // console.log('STATIC ROUTES: ', thing, ctype);
         if (env.isRingoJS()) {
             app.get('/' + thing,
                 function(req, repl) {
@@ -290,15 +294,20 @@ function(thing){
                 });
         }
         else {
-            app.get('/' + thing,
-                function(req, reply) {
-                    // console.log('###STATIC ', thing);
-                    return reply(pup_tent.get(thing))
-                              .type(ctype);
-                });
+          app.route({
+            method: 'GET',
+            path: '/' + thing,
+            handler:
+              function (request, reply) {
+                reply(pup_tent.get(thing)).type(ctype);
+              }
+          });
         }
     }
-});
+    else {
+        // console.log('SKIP STATIC ROUTES: ', thing, ctype);
+    }
+  });
 
 
 // When not in production, re-read files from disk--makes development
@@ -370,11 +379,6 @@ engine.cache = {
 
 // STATIC HELPER FUNCTIONS. May become OO later.
 //o Deprecated with Pup tent
-function getTemplate(t) {
-    var s = env.fs_readFileSync('templates/'+t+'.mustache');
-    return s + '';
-}
-
 function getConfig(t) {
     var s = JSON.parse(env.fs_readFileSync('conf/'+t+'.json'));
     return s;
@@ -530,11 +534,12 @@ function addCoreRenderers(info, type, id, defaults){
     }
     info.includes = {};
     var alys_id = engine.config.analytics_id || null;
-    info.includes.analytics = Mustache.to_html(getTemplate('analytics'),
-                           {'analytics_id': alys_id});
-    info.includes.navbar = Mustache.to_html(getTemplate('navbar'), info);
-    info.includes.footer = Mustache.to_html(getTemplate('footer'), info);
-    info.includes.classificationComponent = Mustache.to_html(getTemplate('classificationComponent'), info);
+
+    info.includes.analytics = pup_tent.render('templates/analytics.mustache',
+                                                {'analytics_id': alys_id});
+    info.includes.navbar = pup_tent.render('templates/navbar.mustache', info);
+    info.includes.footer = pup_tent.render('templates/footer.mustache', info);
+    info.includes.classificationComponent = pup_tent.render('templates/classificationComponent.mustache', info);
 
     info.isProduction = engine.config.type == 'production';
 
@@ -1347,9 +1352,6 @@ app.get('/legacy/disease/:id.:fmt?', function(request, id, fmt) {
 
         var output = pup_tent.render('disease-legacy.mustache',info,'monarch_base.mustache');
         return response.html(output);
-
-        //var r = response.html(Mustache.to_html(getTemplate('disease'), info));
-        return r;
     }
     catch(err) {
         return errorResponse(err);
@@ -1514,7 +1516,6 @@ app.get('/legacy/phenotype/:id.:fmt?', function(request, id, fmt) {
         info.pup_tent_css_libraries.push("/monarch-main.css");
         var output = pup_tent.render('underconstruction.mustache',info,'monarch_base.mustache');
         var res =  response.html(output);
-        //var res = response.html(Mustache.to_html(getTemplate('underconstruction'),info));
         res.status = 404;
         return res;
 
@@ -1581,7 +1582,6 @@ app.get('/legacy/phenotype/:id.:fmt?', function(request, id, fmt) {
 
         var output = pup_tent.render('phenotype-legacy.mustache',info,'monarch_base.mustache');
         return response.html(output);
-        //return response.html(Mustache.to_html(getTemplate('phenotype'), info));
     }
     catch(err) {
         return errorResponse(err);
@@ -1668,7 +1668,6 @@ var fetchLegacyGenotypePage = function(request, id, fmt) {
 
         var output = pup_tent.render('genotype-legacy.mustache',info,'monarch_base.mustache');
         return response.html(output);
-        //return response.html(Mustache.to_html(getTemplate('genotype'), info));
     }
     catch(err) {
         return errorResponse(err);
@@ -1787,8 +1786,8 @@ var fetchModelPage = function(request, id, fmt) {
         info.hasXrefs = function() {return checkExistence(info.database_cross_reference)};
         info.hasEqual = function() {return checkExistence(info.equivalentClasses)};
         info.hasPhenotypes = info.phenotypeNum;
-        info.includes.phenogrid_anchor = Mustache.to_html(getTemplate('phenogrid-anchor'), info);
-        
+        info.includes.phenogrid_anchor = pup_tent.render('templates/phenogrid-anchor.mustache', info);
+
         if (info.hasPhenotypes){
             info.pup_tent_js_libraries.push("/phenogridloader-no-species.js");
             info.monarch_launchable.push('loadPhenogrid()');
@@ -1918,7 +1917,7 @@ var fetchGenotypePage = function(request, id, fmt) {
         info.hasXrefs = function() {return checkExistence(info.database_cross_reference)};
         info.hasEqual = function() {return checkExistence(info.equivalentClasses)};
         info.hasPhenotypes = info.phenotypeNum;
-        info.includes.phenogrid_anchor = Mustache.to_html(getTemplate('phenogrid-anchor'), info);
+        info.includes.phenogrid_anchor = pup_tent.render('templates/phenogrid-anchor.mustache', info);
         
         if (info.hasPhenotypes){
             info.pup_tent_js_libraries.push("/phenogridloader-no-species.js");
@@ -2134,7 +2133,6 @@ app.get('/legacy/gene/:id.:fmt?', function(request, id, fmt) {
 
     var output = pup_tent.render('gene-legacy.mustache',info,'monarch_base.mustache');
     return response.html(output);
-    //return response.html(Mustache.to_html(getTemplate('gene'), info));
 });
 
 var fetchModelLandingPage = function (request, reply){
@@ -2420,7 +2418,7 @@ app.get('/class/:id.:fmt?', function(request, id, fmt) {
     //info.phenotypeTable = function() {return genTableOGenePhenotypeAssociations(info.phenotype_associations)} ;
     //info.alleleTable = function() {return genTableOfDiseaseAlleleAssociations(info.alleles)} ;
 
-    return response.html(Mustache.to_html(getTemplate('class'), info));
+    return response.html(pup_tent.render('templates/class.mustache', info));
 });
 
 app.get('/anatomy', function(request, reply) {
@@ -2464,7 +2462,6 @@ app.get('/anatomy/:id.:fmt?', function(request, id, fmt) {
     //info.phenotypeTable = function() {return genTableOGenePhenotypeAssociations(info.phenotype_associations)} ;
     //info.alleleTable = function() {return genTableOfDiseaseAlleleAssociations(info.alleles)} ;
 
-    //return response.html(Mustache.to_html(getTemplate('anatomy'), info));
     var output = pup_tent.render('anatomy.mustache',info,'monarch_base.mustache');
     return response.html(output);
 });
@@ -2515,7 +2512,6 @@ app.get('/literature/:id.:fmt?', function(request, id, fmt) {
     info.similarPapersTable = function() { return genTableOfSimilarPapers(info.similarPapers) };
     info.genesTable = function() { return genTableOfLiteratureGenes(info.genes) };
 
-    //return response.html(Mustache.to_html(getTemplate('literature'), info));
     var output = pup_tent.render('literature.mustache',info,'monarch_base.mustache');
     return response.html(output);
 });
@@ -2802,7 +2798,7 @@ function annotateByTextHandler(request, fmt) {
 
     info.title = "Annotation";
     info.hasResults = (info.results.length > 0);
-    //return response.html(Mustache.to_html(getTemplate('annotate'), info));
+
     var output = pup_tent.render('annotate.mustache',info,'monarch_base.mustache');
     return web.wrapHTML(output);
 }
@@ -2835,7 +2831,6 @@ app.get('/annotate_minimal/text.:fmt?', function(request, fmt) {
     info.hasResults = (info.results.length > 0);
     var output = pup_tent.render('annotate_minimal.mustache',info,'monarch_base.mustache');
     return response.html(output);
-    //return response.html(Mustache.to_html(getTemplate('annotate_minimal'), info));
 });
 
 app.get('/sufficiency/basic.:fmt?', function(request, datatype, fmt) {
@@ -2933,7 +2928,6 @@ app.get('/labs',
         addCoreRenderers(info);
         info.pup_tent_css_libraries.push("/tour.css");
         info.title = 'Monarch Labs'
-        //return response.html(Mustache.to_html(getTemplate('labs'), info));
         var output = pup_tent.render('labs.mustache', info,
 				     'monarch_base.mustache');
         return response.html(output);
@@ -3035,7 +3029,6 @@ app.get('/labs/cy-path-demo',
 
         info.title = 'cy-path-demo';
 
-        //return response.html(Mustache.to_html(getTemplate('labs/cy-path-demo'), info));
         var output = pup_tent.render('cy-path-demo.mustache',info,'monarch_base.mustache');
         return response.html(output);
 });
@@ -3054,8 +3047,6 @@ app.get('/labs/cy-explore-demo',
         info.pup_tent_js_libraries.push("/CyExploreDemo.js");
         info.pup_tent_css_libraries.push("/monarch-labs.css");
         info.pup_tent_css_libraries.push("/tour.css");
-
-        //return response.html(Mustache.to_html(getTemplate('labs/cy-explore-demo'), info));
 
         info.title = 'cy-explore-demo';
 
@@ -3717,8 +3708,9 @@ function diseaseByIdHandler(request, id, fmt) {
     if (info.phenotypeNum > 10000){
         info.hasPhenotypes = false;
     }
-    info.includes.phenogrid_anchor = Mustache.to_html(getTemplate('phenogrid-anchor'), info);
-    
+
+    info.includes.phenogrid_anchor = pup_tent.render('templates/phenogrid-anchor.mustache', info);
+
     //Variables and launcher for ontology view
     info.pup_tent_js_variables.push({name:'global_scigraph_url',
         value: engine.config.scigraph_url});
@@ -3761,7 +3753,7 @@ web.wrapRouteGet(app, '/disease/:id', '/disease/{id}', ['id'], diseaseByIdHandle
 web.wrapRouteGet(app, '/disease/:id/:section.:fmt?', '/disease/{id}/{section}.{fmt?}', ['id', 'section', 'fmt'],
     function(request, id, section, fmt){
         var info = engine.fetchCoreDiseaseInfo(id);
-
+        console.log('####fetchCoreDiseaseInfo returns:', JSON.stringify(info));
         var sectionInfo =
              { id: "obo:"+id }; // <-- TODO - unify ID/URI strategy
         sectionInfo[section] = info[section];
@@ -3930,7 +3922,7 @@ web.wrapRouteGet(app, '/gene/:id.:fmt?', '/gene/{id}', ['id'],
             info.monarch_launchable.push('loadPhenogrid()');
         }
         
-        info.includes.phenogrid_anchor = Mustache.to_html(getTemplate('phenogrid-anchor'), info);
+        info.includes.phenogrid_anchor = pup_tent.render('templates/phenogrid-anchor.mustache', info);
         
         var output = pup_tent.render('gene.mustache', info,
                  'monarch_base.mustache');
@@ -4122,7 +4114,7 @@ var fetchVariantPage = function(request, id, fmt) {
             info.monarch_launchable.push('loadPhenogrid()');
         }
         
-        info.includes.phenogrid_anchor = Mustache.to_html(getTemplate('phenogrid-anchor'), info);
+        info.includes.phenogrid_anchor = pup_tent.render('templates/phenogrid-anchor.mustache', info);
         
         //Launch function for annotation score
         info.pup_tent_js_variables.push({name:'globalID',value:id});
@@ -4172,7 +4164,7 @@ app.get('/labs/case/:id', function(request, id, fmt){
     info.monarch_launchable.push('loadPhenogrid()');
     
     info.hasPhenotypes = true;
-    info.includes.phenogrid_anchor = Mustache.to_html(getTemplate('phenogrid-anchor'), info);
+    info.includes.phenogrid_anchor = pup_tent.render('templates/phenogrid-anchor.mustache', info);
     
     info.pup_tent_css_libraries.push("/monarch-main.css");
     info.pup_tent_css_libraries.push("/monarch-specific.css");
@@ -4279,98 +4271,99 @@ function addPhenotypeAnchor(info) {
     var phenotype_anchor = {id: info.id,
                             resultNum: info.phenotypeNum,
                             type: "Phenotypes", href: "phenotypes"};
-    return Mustache.to_html(getTemplate('anchor'), phenotype_anchor);
+
+    return pup_tent.render('templates/anchor.mustache', phenotype_anchor);
 }
 
 function addPhenotypeTable(info) {
     var phenotype_table = {href: "phenotypes", div: "phenotypes-table",
                            isLeafNode: info.isLeafNode,
                            isPhenotypeTable : true};
-    return Mustache.to_html(getTemplate('golr-table'), phenotype_table);
+    return pup_tent.render('templates/golr-table.mustache', phenotype_table);
 }
 
 function addDiseaseAnchor(info) {
     var disease_anchor = {id: info.id,
                           resultNum: info.diseaseNum,
                           type: "Disease", href: "diseases"};
-    return Mustache.to_html(getTemplate('anchor'), disease_anchor);
+    return pup_tent.render('templates/anchor.mustache', disease_anchor);
 }
 
 function addDiseaseTable() {
     var disease_table = {href: "diseases", div: "disease-table"};
-    return Mustache.to_html(getTemplate('golr-table'), disease_table);
+    return pup_tent.render('templates/golr-table.mustache', disease_table);
 }
 
 function addGeneAnchor(info) {
     var gene_anchor = {id: info.id,
                        resultNum: info.geneNum,
                        type: "Genes", href: "genes"};
-    return Mustache.to_html(getTemplate('anchor'), gene_anchor);
+    return pup_tent.render('templates/anchor.mustache', gene_anchor);
 }
 
 function addGeneTable() {
     var gene_table = {href: "genes", div: "gene-table"}
-    return Mustache.to_html(getTemplate('golr-table'), gene_table);
+    return pup_tent.render('templates/golr-table.mustache', gene_table);
 }
 
 function addModelAnchor(info) {
     var model_anchor = {id: info.id,
                         resultNum: info.modelNum,
                         type: "Models", href: "models"};
-    return Mustache.to_html(getTemplate('anchor'), model_anchor);
+    return pup_tent.render('templates/anchor.mustache', model_anchor);
 }
 
 function addModelTable() {
     var model_table = {href: "models", div: "model-table"};
-    return Mustache.to_html(getTemplate('golr-table'), model_table);
+    return pup_tent.render('templates/golr-table.mustache', model_table);
 }
 
 function addVariantAnchor(info) {
     var variant_anchor = {id: info.id, type: "Variants",
                           resultNum: info.variantNum,
                           href: "variants"};
-    return Mustache.to_html(getTemplate('anchor'), variant_anchor);
+    return pup_tent.render('templates/anchor.mustache', variant_anchor);
 }
 
 function addVariantTable() {
     var variant_table = {href: "variants", div: "variant-table"};
-    return Mustache.to_html(getTemplate('golr-table'), variant_table);
+    return pup_tent.render('templates/golr-table.mustache', variant_table);
 }
 
 function addHomologAnchor(info) {
     var homolog_anchor = {id: info.id, type: "Homologs",
                           resultNum: info.homologNum,
                           href: "homologs"};
-    return Mustache.to_html(getTemplate('anchor'), homolog_anchor);
+    return pup_tent.render('templates/anchor.mustache', homolog_anchor);
 }
 
 function addHomologTable() {
     var homologs_table = {href: "homologs", div: "homolog-table"};
-    return Mustache.to_html(getTemplate('golr-table'), homologs_table);
+    return pup_tent.render('templates/golr-table.mustache', homologs_table);
 }
 
 function addPathwayAnchor(info) {
     var pathway_anchor = {id: info.id, type: "Pathways",
                           resultNum: info.pathwayNum,
                           href: "pathways"};
-    return Mustache.to_html(getTemplate('anchor'), pathway_anchor);
+    return pup_tent.render('templates/anchor.mustache', pathway_anchor);
 }
 
 function addPathwayTable() {
     var pathway_table = {href: "pathways", div: "pathway-table"};
-    return Mustache.to_html(getTemplate('golr-table'), pathway_table);
+    return pup_tent.render('templates/golr-table.mustache', pathway_table);
 }
 
 function addGenotypeAnchor(info) {
     var genotype_anchor = {id: info.id,
                             resultNum: info.genotypeNum,
                             type: "Genotypes", href: "genotypes"};
-    return Mustache.to_html(getTemplate('anchor'), genotype_anchor);
+    return pup_tent.render('templates/anchor.mustache', genotype_anchor);
 }
 
 function addGenotypeTable() {
     var genotype_table = {href: "genotypes", div: "genotype-table"};
-    return Mustache.to_html(getTemplate('golr-table'), genotype_table);
+    return pup_tent.render('templates/golr-table.mustache', genotype_table);
 }
 
 
@@ -4460,7 +4453,6 @@ app.get('/*',function(request) {
     info.title = 'Page Not Found';
     var output = pup_tent.render('notfound.mustache',info,'monarch_base.mustache');
     var res =  response.html(output);
-    //var res = response.html(Mustache.to_html(getTemplate('notfound'),info));
     res.status = 404;
     return res;
 });
@@ -4572,7 +4564,6 @@ app.get('/labs/gene/:id.:fmt?', function(request, id, fmt) {
 
     var output = pup_tent.render('gene-jbrowse.mustache',info,'monarch_base.mustache');
     return response.html(output);
-    //return response.html(Mustache.to_html(getTemplate('gene'), info));
 });
 
 

--- a/modules/pup-tent/pup-tent.js
+++ b/modules/pup-tent/pup-tent.js
@@ -223,29 +223,32 @@ module.exports = function(search_path_list, filename_list){
     // Make sure the file is there, then save it to the
     // appropriate caches.
     function _check_and_save(path){
-	//console.log('l@: ' + path);
+    	var cache_exclusions_re = /\.DS_Store$/;
 	if( afs.exists_p(path) ){
-	    if( afs.file_p(path) ){
+	    if( afs.file_p(path) && !cache_exclusions_re.test(path)){
 		//console.log('found file: ' + path);
-		
+
 		// Break into parts for saving if it is a full file.
 		var filename = path;
 		var slash_loc = path.lastIndexOf('/') + 1;
-		if( slash_loc != 0 ){
+		if( slash_loc !== 0 ){
 		    filename = path.substr(slash_loc, path.length);
 		}
-		
+
 		// Capture full path.
 		path_cache[path] = path;
 		zcache[path] = afs.read_file(path);
-		
+
 		// Capture flattened name.
 		path_cache[filename] = path;
 		zcache[filename] = afs.read_file(path);
-		
+
 		// Capture which is which.
 		ns_cache_flat[filename] = true;
 		ns_cache_full[path] = true;
+	    }
+	    else {
+          // console.log('_check_and_save EXCLUDE:', path);
 	    }
 	}
     }


### PR DESCRIPTION
Fixes the use of NodeJS request to be compatible with the ringo/request.

Mostly this involved the use of the 'useQuerystring' option to ensure
that parameters are encoded in form-url-encoded mode.

Removes use of getTemplate() in webapp and the explicit use of mustache
in favor of calling puptent's render() method.

Deletes lots of dead code.
