### PR TITLE
More routes converted to NodeJS/RingoJS mode. Re-enables Phenogrid test that was disabled for CORS.

### DIFF
--- a/lib/monarch/web/webapp.js
+++ b/lib/monarch/web/webapp.js
@@ -636,43 +636,6 @@ function formattedResults(info, fmt, request) {
     }
 }
 
-/*
-
-function responseError(s) {
-    if (env.isRingoJS()) {
-        return response.error(s);
-    }
-    else {
-        return {
-            body: [s],
-            headers: {'Content-Type': 'text/plain'},
-            status: 200
-        };
-    }
-}
-
-
-function errorResponse(msg, errorCode) {
-    var info = {};
-    addCoreRenderers(info);
-    //print(JSON.stringify(msg));
-    console.error("Throwing error:" + msg);
-    for (var k in msg) {
-        console.warn("  :"+k+"="+msg[k]);
-    }
-    var stm = require("ringo/logging").getScriptStack(msg);
-    console.error("Stack trace="+stm);
-    //info.message = JSON.stringify(msg, null, ' ');
-    info.stackTrace = stm;
-    info.message = msg.message;
-    info.pup_tent_css_libraries.push("/monarch-main.css");
-    info.title = 'Error';
-    var output = pup_tent.render('notfound.mustache',info,'monarch_base.mustache');
-    var res =  response.html(output);
-    res.status = errorCode || 500;
-    return res;
-}
-*/
 
 function errorResponse(msg, errorCode) {
     var info = {};
@@ -688,9 +651,9 @@ function errorResponse(msg, errorCode) {
     console.error("Stack trace="+stm);
     //info.message = JSON.stringify(msg, null, ' ');
     info.stackTrace = stm;
-    info.message = msg.message;
+    info.message = msg;
     info.pup_tent_css_libraries.push("/monarch-main.css");
-    info.title = 'Error';
+    info.title = (errorCode === 404) ? 'Page Not Found' : 'Error';
     var template = (errorCode === 404) ? 'notfound.mustache' : 'error.mustache';
     var output = pup_tent.render(template,info,'monarch_base.mustache');
     return web.wrapHTML(output, errorCode);
@@ -735,6 +698,7 @@ web.wrapRouteGet(app, '/status', '/status', [],
         status['message'] =  'okay';
         status['date'] = (new Date()).toString();
         status['location'] = request.url || request.pathInfo || '???';
+        status['platform'] = env.isRingoJS() ? 'ringojs' : 'nodejs';
         status['offerings'] = [
             {'name': 'api_version', 'value': engine.apiVersionInfo()},
             {'name': 'config_type', 'value': engine.config.type},
@@ -1160,7 +1124,7 @@ web.wrapRouteGet(app, '/autocomplete/:term', '/autocomplete/{term}', ['term'], a
 web.wrapRouteGet(app, '/disease', '/disease', [],
   function(request) {
     var info = prepLandingPage();
-    info.blog_results = loadBlogData('disease-news', 4);
+    //info.blog_results = loadBlogData('disease-news', 4);
 
     info.spotlight = engine.fetchSpotlight('disease');
     //info.spotlight.link = genObjectHref('disease',{id:info.spotlight.id, label:"Explore"});
@@ -1447,9 +1411,10 @@ app.get('/legacy/disease/:id/:section.:fmt?', function(request, id, section, fmt
 // Returns:
 //  Phenotype with matching ID
 
-app.get('/phenotype', function(request, reply) {
+
+function phenotypeLandingHandler(request) {
     var info = prepLandingPage();
-    info.blog_results = loadBlogData('phenotype-news', 4);
+    //info.blog_results = loadBlogData('phenotype-news', 4);
    
     //spotlight
     info.spotlight = engine.fetchSpotlight('phenotype');
@@ -1512,8 +1477,10 @@ app.get('/phenotype', function(request, reply) {
     info.title = 'Monarch Phenotypes';
     
     var output = pup_tent.render('phenotype_main.mustache', info,'monarch_base.mustache');
-    return web.wrapResponse(request, reply, web.wrapHTML(output));
-});
+    return web.wrapHTML(output);
+}
+
+web.wrapRouteGet(app, '/phenotype', '/phenotype', [], phenotypeLandingHandler);
 
 app.get('/legacy/phenotype/:id.:fmt?', function(request, id, fmt) {
 
@@ -1686,7 +1653,8 @@ var fetchLegacyGenotypePage = function(request, id, fmt) {
     }
 };
 
-var fetchModelPage = function(request, id, fmt) {
+
+function modelByIdHandler(request, id, fmt) {
     try {
         // Rendering.
         var info = {};
@@ -1818,7 +1786,12 @@ var fetchModelPage = function(request, id, fmt) {
     }
 };
 
-var fetchGenotypePage = function(request, id, fmt) {
+// Order matters here in the declaration of these routes.
+web.wrapRouteGet(app, '/model/:id.:fmt?', '/model/{id}.{fmt}', ['id', 'fmt'], modelByIdHandler);
+web.wrapRouteGet(app, '/model/:id', '/model/{id}', ['id'], modelByIdHandler);
+
+
+function genotypeByIdHandler(request, id, fmt) {
     try {
         // Rendering.
         var info = {};
@@ -1942,26 +1915,32 @@ var fetchGenotypePage = function(request, id, fmt) {
     
         var output = pup_tent.render('genotype.mustache', info,
                                      'monarch_base.mustache');
-        return response.html(output);     
+        return web.wrapHTML(output);
     }
     catch(err) {
         return errorResponse(err);
     }
 };
 
+// Order matters here in the declaration of these routes.
+web.wrapRouteGet(app, '/genotype/:id.:fmt?', '/genotype/{id}.{fmt}', ['id', 'fmt'], genotypeByIdHandler);
+web.wrapRouteGet(app, '/genotype/:id', '/genotype/{id}', ['id'], genotypeByIdHandler);
+
+
 var genMGIXRef = function genMGIXRef(id){
     return "<a href=\"http://www.informatics.jax.org/allele/genoview/" +
             id + "\" target=\"_blank\">" + id + "</a>";
 };
 
-app.get('/genotype/:id.:fmt?', fetchGenotypePage);
+
+
 app.get('/legacy/genotype/:id.:fmt?', fetchLegacyGenotypePage);
 
 
 // GENOTYPE - Sub-pages
 // Example: /genotype/MGI_4420313/genotype_associations.json
 // Currently only works for json or rdf output
-var fetchGenotypeSection =  function(request, id, section, fmt) {
+var fetchLegacyGenotypeSection =  function(request, id, section, fmt) {
     var newId = engine.resolveClassId(id);
     if (newId != id) {
         engine.log("redirecting: "+id+" ==> "+newId);
@@ -1983,11 +1962,13 @@ var fetchGenotypeSection =  function(request, id, section, fmt) {
     }
 };
 
-app.get('/legacy/genotype/:id./:section.:fmt?',fetchGenotypeSection);
+app.get('/legacy/genotype/:id./:section.:fmt?',fetchLegacyGenotypeSection);
 
-app.get('/gene', function(request, reply) {
+
+
+function geneLandingPageHandler(request) {
     var info = prepLandingPage();
-    info.blog_results = loadBlogData('gene-news', 4);
+    //info.blog_results = loadBlogData('gene-news', 4);
     info.spotlight = engine.fetchSpotlight('gene');
     //info.spotlight.link = genObjectHref('gene',{id:info.spotlight.id, label:"Explore"});
     info.spotlight.link = genObjectHref('gene',info.spotlight);
@@ -2043,8 +2024,10 @@ app.get('/gene', function(request, reply) {
     info.title = 'Monarch Genes';
 
     var output = pup_tent.render('gene_main.mustache', info,'monarch_base.mustache');
-    return web.wrapResponse(request, reply, web.wrapHTML(output));
-});
+    return web.wrapHTML(output);
+}
+web.wrapRouteGet(app, '/gene', '/gene', [], geneLandingPageHandler);
+
 
 // Status: STUB
 app.get('/legacy/gene/:id.:fmt?', function(request, id, fmt) {
@@ -2147,10 +2130,10 @@ app.get('/legacy/gene/:id.:fmt?', function(request, id, fmt) {
     return response.html(output);
 });
 
-var fetchModelLandingPage = function (request, reply){
+function modelLandingPageHandler(request){
     
     var info = prepLandingPage();
-    info.blog_results = loadBlogData('model-news', 4);
+    //info.blog_results = loadBlogData('model-news', 4);
 
     //spotlight
     info.spotlight = engine.fetchSpotlight('model');
@@ -2207,11 +2190,11 @@ var fetchModelLandingPage = function (request, reply){
     info.title = 'Monarch Models';
     
     var output = pup_tent.render('model_main.mustache', info,'monarch_base.mustache');
-    return web.wrapResponse(request, reply, web.wrapHTML(output));
+    return web.wrapHTML(output);
 }
 
-app.get('/model', fetchModelLandingPage);
-app.get('/genotype', fetchModelLandingPage);
+web.wrapRouteGet(app, '/model', '/model', [], modelLandingPageHandler);
+web.wrapRouteGet(app, '/genotype', '/genotype', [], modelLandingPageHandler);
 
 function getGeneMapping(id) {
     var mappedID;
@@ -2253,7 +2236,7 @@ app.get('/legacy/gene/:id/:section.:fmt?', function(request, id, section, fmt) {
 //For receiving of HPO relations for Phenogrid
 //Example: /neighborhood/HP_0003273/2/out/subClassOf.json
 
-function neighborhoodHandler(request, id, depth, direction, relationship, fmt) {
+function neighborhoodByIdDepthDirectionRelationshipHandler(request, id, depth, direction, relationship, fmt) {
   var info = engine.getGraphNeighbors(id, depth, relationship, direction);
 
   if (fmt != null) {
@@ -2264,38 +2247,17 @@ function neighborhoodHandler(request, id, depth, direction, relationship, fmt) {
   }
 }
 
-if (env.isRingoJS()) {
-  app.get('/neighborhood/:id/:depth/:direction/:relationship.:fmt?', function(request, id, depth, direction, relationship, fmt) {
-    var output = neighborhoodHandler(request, id, depth, direction, relationship, fmt);
-    return output;
-  });
-}
-else {
-  app.route({
-    method: 'GET',
-    path: '/neighborhood/{id}/{depth}/{direction}/{relationship}.{fmt?}',
-    handler:
-        function (request, reply) {
-          WaitFor.launchFiber(function () {
-            var id = request.params.id;
-            var depth = request.params.depth;
-            var direction = request.params.direction;
-            var relationship = request.params.relationship;
-            var fmt = request.params.fmt;
+// Order matters here in the declaration of these routes.
+web.wrapRouteGet(app, '/neighborhood/:id/:depth/:direction/:relationship.:fmt?', '/neighborhood/{id}/{depth}/{direction}/{relationship}.{fmt}', ['id', 'depth', 'direction', 'relationship', 'fmt'], neighborhoodByIdDepthDirectionRelationshipHandler);
+web.wrapRouteGet(app, '/neighborhood/:id/:depth/:direction/:relationship', '/neighborhood/{id}/{depth}/{direction}/{relationship}', ['id', 'depth', 'direction', 'relationship'], neighborhoodByIdDepthDirectionRelationshipHandler);
 
-            var output = neighborhoodHandler(request, id, depth, direction, relationship, fmt);
-            reply(output);
-          });
-        }
-  });
-}
+
 
 // Status: STUB
 // this just calls the genotype page - TODO
 app.get('/legacy/model/:id.:fmt?', fetchLegacyGenotypePage);
-app.get('/legacy/model/:id/:section.:fmt?', fetchGenotypeSection);
+app.get('/legacy/model/:id/:section.:fmt?', fetchLegacyGenotypeSection);
 
-web.wrapRouteGet(app, '/model/:id.:fmt?', '/model/{id}', ['id', 'fmt'], fetchModelPage);
 
 
 // Status: STUB
@@ -2403,13 +2365,15 @@ app.get('/legacy/variant/:id.:fmt?', function(request, id, fmt) {
     return web.wrapRedirect(url);
 });
 
-app.get('/class', function(request, reply) {
-    return web.wrapResponse(request, reply, web.wrapHTML(staticTemplate('class_main')));
-});
+
+web.wrapRouteGet(app, '/class', '/class', [],
+    function(request) {
+        return web.wrapHTML(staticTemplate('class_main'));
+    });
 
 // generic ontology view - most often this will be overridden, e.g. a disease class
 // Status: STUB
-app.get('/class/:id.:fmt?', function(request, id, fmt) {
+function classByIdHandler(request, id, fmt) {
     var opts =
         {
             level : request.params.level
@@ -2430,14 +2394,20 @@ app.get('/class/:id.:fmt?', function(request, id, fmt) {
     //info.phenotypeTable = function() {return genTableOGenePhenotypeAssociations(info.phenotype_associations)} ;
     //info.alleleTable = function() {return genTableOfDiseaseAlleleAssociations(info.alleles)} ;
 
-    return response.html(expandTemplate('class', info));
-});
+    return web.wrapHTML(expandTemplate('class', info));
+}
 
-app.get('/anatomy', function(request, reply) {
-    return web.wrapResponse(request, reply, web.wrapHTML(staticTemplate('anatomy_main')));
-});
+// Order matters here in the declaration of these routes.
+web.wrapRouteGet(app, '/class/:id.:fmt?', '/class/{id}.{fmt}', ['id', 'fmt'], classByIdHandler);
+web.wrapRouteGet(app, '/class/:id', '/class/{id}', ['id'], classByIdHandler);
 
-app.get('/anatomy/:id.:fmt?', function(request, id, fmt) {
+
+web.wrapRouteGet(app, '/anatomy', '/anatomy', [],
+    function(request) {
+        return web.wrapHTML(staticTemplate('anatomy_main'));
+    });
+
+function anatomyByIdHandler(request, id, fmt) {
     var info = engine.fetchAnatomyInfo(id);  // OQ
     if (fmt != null) {
     return formattedResults(info,fmt,request);
@@ -2475,15 +2445,22 @@ app.get('/anatomy/:id.:fmt?', function(request, id, fmt) {
     //info.alleleTable = function() {return genTableOfDiseaseAlleleAssociations(info.alleles)} ;
 
     var output = pup_tent.render('anatomy.mustache',info,'monarch_base.mustache');
-    return response.html(output);
-});
+    return web.wrapHTML(output);
+}
+
+
+// Order matters here in the declaration of these routes.
+web.wrapRouteGet(app, '/anatomy/:id.:fmt?', '/anatomy/{id}.{fmt}', ['id', 'fmt'], anatomyByIdHandler);
+web.wrapRouteGet(app, '/anatomy/:id', '/anatomy/{id}', ['id'], anatomyByIdHandler);
+
 
 /* Literature Pages */
-app.get('/literature', function(request, reply) {
-    return web.wrapResponse(request, reply, web.wrapHTML(staticTemplate('literature_main')));
-});
+web.wrapRouteGet(app, '/literature', '/literature', [],
+    function(request) {
+        return web.wrapHTML(staticTemplate('literature_main'));
+    });
 
-app.get('/literature/:id.:fmt?', function(request, id, fmt) {
+function literatureByIdHandler(request, id, fmt) {
     var info;
     var regex = /^PMID:(\d+)$/;
     var regres = regex.exec(id);
@@ -2525,8 +2502,13 @@ app.get('/literature/:id.:fmt?', function(request, id, fmt) {
     info.genesTable = function() { return genTableOfLiteratureGenes(info.genes) };
 
     var output = pup_tent.render('literature.mustache',info,'monarch_base.mustache');
-    return response.html(output);
-});
+    return web.wrapHTML(output);
+}
+
+
+// Order matters here in the declaration of these routes.
+web.wrapRouteGet(app, '/literature/:id.:fmt?', '/literature/{id}.{fmt}', ['id', 'fmt'], literatureByIdHandler);
+web.wrapRouteGet(app, '/literature/:id', '/literature/{id}', ['id'], literatureByIdHandler);
 
 function getIdentifierList(params) {
     var input_items;
@@ -2560,23 +2542,23 @@ function mapStyleToCategories(style) {
     return categories;
 }
 
-var scoreFunction = function (request){
+function scoreHandler(request) {
     engine.log("Ready to score");
     engine.log("Params:"+JSON.stringify(request.params));
     var target = null;
-    var categories = request.params.categories || [];
+    var categories = web.getParam(request, 'categories') || [];
     //default to phenotips categories.
     //TODO: make monarch categories
-    var style = request.params.style || 'phenotips';
+    var style = web.getParam(request, 'style') || 'phenotips';
     categories = mapStyleToCategories(style);
-    var annotation_profile = request.params.annotation_profile;
+    var annotation_profile = web.getParam(request, 'annotation_profile');
     annotation_profile = JSON.parse(annotation_profile);
     var myresults = engine.getInformationProfile(annotation_profile,categories);
-    return response.json(myresults);
-};
+    return web.wrapJSON(myresults);
+}
 
-app.get('/score', scoreFunction);
-app.post('/score', scoreFunction);
+web.wrapRouteGet(app, '/score', '/score', [], scoreHandler);
+web.wrapRoutePost(app, '/score', '/score', [], scoreHandler);
 
 
 // Method: simsearch
@@ -2610,7 +2592,7 @@ app.post('/score', scoreFunction);
 // Returns:
 //  List of matching entities
 
-function simsearchDiseaseById(request, id, fmt) {
+function simsearchDiseaseByIdHandler(request, id, fmt) {
     engine.log("Params:"+JSON.stringify(request.params));
     var target = null;
     var info = {datatype: 'disease', results:[]};
@@ -2619,104 +2601,38 @@ function simsearchDiseaseById(request, id, fmt) {
     var limit = request.params.cutoff || request.params.limit || 10;
 
     info.results = engine.searchByDisease(id,target_species,limit);
-    return info.results;
+    return web.wrapJSON(info.results);
 }
 
 
-if (env.isRingoJS()) {
-    app.get('/simsearch/disease/:id.:fmt?', function (request, id, fmt) {
-            var output = simsearchDiseaseById(request, id, fmt);
-            return web.wrapResponse(request, null, web.wrapJSON(output));
-        }
-    );
-}
-else {
-    app.route({
-        method: 'GET',
-        path: '/simsearch/disease/{id}.{fmt?}',
-        handler:
-            function (request, reply) {
-              WaitFor.launchFiber(function () {
-                var id = request.params.id;
-                var fmt = request.params.fmt;
-                var output = simsearchDiseaseById(request, id, fmt);
-                return web.wrapResponse(request, reply, web.wrapJSON(output));
-              });
-            }
-    });
-}
+// Order matters here in the declaration of these routes.
+web.wrapRouteGet(app, '/simsearch/disease/:id.:fmt?', '/simsearch/disease/{id}.{fmt}', ['id', 'fmt'], simsearchDiseaseByIdHandler);
+web.wrapRouteGet(app, '/simsearch/disease/:id', '/simsearch/disease/{id}', ['id'], simsearchDiseaseByIdHandler);
 
 
 
-var simsearchPhenotype = function(request, fmt, target_species, target_type, limit, input_items) {
+function simsearchPhenotypeByTargetTypeLimitItemsHandler(request) {
+    var target_species = web.getParam(request, 'target_species');
+    var target_type = web.getParam(request, 'target_type');
+    var cutoff = web.getParam(request, 'cutoff');
+    var limit = cutoff || web.getParam(request, 'limit') || 100;
+    var input_items_a = web.getParam(request, 'a');
+    var input_items = web.getParam(request, 'input_items');
+console.log('params:', Object.keys(request.params));
+console.log('input_items_a:', input_items_a);
+console.log('input_items:', input_items);
+    input_items = input_items_a || itemsToArray(input_items);
+
     var target = null;
     var info = {results:[]};
-    //input_items = engine.mapIdentifiersToPhenotypes( input_items );
     info.results = engine.searchByPhenotypeProfile(input_items,target_species,null,limit);
 
-    return info.results;
-
-};
-
-if (env.isRingoJS()) {
-    app.get('/simsearch/phenotype.:fmt?', function (request, fmt) {
-            var target_species = request.params.target_species; //|| '9606'; //default to human
-            var target_type = request.params.target_type; //|| 'disease';
-            var limit = request.params.cutoff || request.params.limit || 100;
-            var input_items = getIdentifierList(request.params);
-
-            var output = simsearchPhenotype(request, fmt, target_species, target_type, limit, input_items);
-            return response.json(output);
-        }
-    );
-    app.post('/simsearch/phenotype.:fmt?', function (request, fmt) {
-            var target_species = request.params.target_species; //|| '9606'; //default to human
-            var target_type = request.params.target_type; //|| 'disease';
-            var limit = request.params.cutoff || request.params.limit || 100;
-            var input_items = getIdentifierList(request.params);
-
-            var output = simsearchPhenotype(request, fmt, target_species, target_type, limit, input_items);
-            return response.json(output);
-        }
-    );
-}
-else {
-    app.route({
-        method: 'GET',
-        path: '/simsearch/phenotype.{fmt?}',
-        handler:
-            function (request, reply) {
-              WaitFor.launchFiber(function () {
-                var fmt = request.params.fmt;
-                var target_species = request.params.target_species; //|| '9606'; //default to human
-                var target_type = request.params.target_type; //|| 'disease';
-                var limit = request.params.cutoff || request.params.limit || 100;
-                var input_items = getIdentifierList(request.params);
-
-                var output = simsearchPhenotype(request, fmt, target_species, target_type, limit, input_items);
-                reply(output);
-              });
-            }
-    });
-    app.route({
-        method: 'POST',
-        path: '/simsearch/phenotype',
-        handler:
-            function (request, reply) {
-              WaitFor.launchFiber(function () {
-                var fmt = request.payload.fmt;
-                var target_species = request.payload.target_species; //|| '9606'; //default to human
-                var target_type = request.payload.target_type; //|| 'disease';
-                var limit = request.payload.cutoff || request.payload.limit || 100;
-                var input_items = getIdentifierList(request.payload);
-
-                var output = simsearchPhenotype(request, fmt, target_species, target_type, limit, input_items);
-                reply(output);
-              });
-            }
-    });
+    return web.wrapJSON(info.results);
 }
 
+
+// web.wrapRouteGet(app, '/simsearch/phenotype', '/simsearch/phenotype', [], simsearchPhenotypeByTargetTypeLimitItemsHandler);
+web.wrapRoutePost(app, '/simsearch/phenotype', '/simsearch/phenotype', [], simsearchPhenotypeByTargetTypeLimitItemsHandler);
 
 function annotateByTextHandler(request, fmt) {
     var q = env.isRingoJS() ? request.params.q : request.query.q;
@@ -3119,7 +3035,7 @@ function _get_blog_data(label) {
   // cached results are empty.
   var res = [];
   var now = _get_now_sec()
-  if( (now - _blog_data_last_time) < _blog_data_last_step && _blog_data_last_res.length > 0 ) {
+  if ((now - _blog_data_last_time) < _blog_data_last_step && _blog_data_last_res.length > 0 ) {
     // Used cached list
     engine.log('blog: using cached results');
     res = _blog_data_last_res;
@@ -3276,34 +3192,11 @@ function homeHandler(request) {
   info.title = 'Welcome to Monarch';
   var output = pup_tent.render('home-page.mustache', info,
        'monarch-base-bs3.mustache');
-  return output;
+  return web.wrapHTML(output);
 }
 
-if (env.isRingoJS()) {
-    app.get('/',
-        function (request, id, fmt) {
-            try {
-                var output = homeHandler(request);
-                return response.html(output);
-            } catch(err) {
-                return errorResponse(err);
-            }
-        }
-    );
-}
-else {
-    app.route({
-        method: 'GET',
-        path: '/',
-        handler:
-            function (request, reply) {
-              WaitFor.launchFiber(function () {
-                var output = homeHandler(request);
-                reply(output);
-              });
-            }
-    });
-}
+web.wrapRouteGet(app, '/', '/', [], homeHandler);
+
 
 app.get('/labs/scratch-homepage', function(request, page){
 
@@ -4458,18 +4351,12 @@ app.get('/labs/jbrowse-demo', function(request){
 /// Error handling.
 ///
 
-// Add an error for all of the rest.
-app.get('/*',function(request) {
-    var info = {};
-    addCoreRenderers(info);
-    info.pup_tent_css_libraries.push("/monarch-main.css");
-    info.title = 'Page Not Found';
-    var output = pup_tent.render('notfound.mustache',info,'monarch_base.mustache');
-    var res =  response.html(output);
-    res.status = 404;
-    return res;
-});
 
+// Add an error for all of the rest.
+function notFoundHandler(request) {
+    return notFoundResponse('Page Not Found');
+}
+web.wrapRouteGet(app, '/*', '/{other*}', [], notFoundHandler);
 
 if (env.isRingoJS()) {
     // INITIALIZATION

--- a/lib/monarch/web/webenv.js
+++ b/lib/monarch/web/webenv.js
@@ -118,7 +118,15 @@ else {
     var WaitFor = require('wait.for');
 
     function getParam(request, name) {
-        return request.params[name] || request.query[name];
+        var result = request.params[name];
+        if (!result && request.query) {
+            result = request.query[name];
+        }
+        if (!result && request.payload) {
+            result = request.payload[name];
+        }
+
+        return result;
     }
 
     function wrapRedirect(uri) {

--- a/tests/behave/maui_basic.feature
+++ b/tests/behave/maui_basic.feature
@@ -53,12 +53,18 @@ Feature: Monarch-app UI basic pages display okay
     Given I go to page "/resolve/OMIM_600669"
      then the url will be "/disease/OMIM:600669"
 
- @ui
- Scenario: Going to the page /resolve/Bogus:123 will produce a Page Not Found error
+@ui
+Scenario: Going to the page /resolve/Bogus:123 will produce a Page Not Found error
     Given I go to page "/resolve/Bogus:123"
      then the document should contain "Sorry. Your page could not be found"
-     and the title should be "Error"
-     
+     and the title should be "Page Not Found"
+
+@ui
+Scenario: Going to the page /NoSuchPath will produce a Page Not Found error
+    Given I go to page "/NoSuchPath"
+    then the document should contain "Sorry. Your page could not be found"
+    and the title should be "Page Not Found"
+
  @ui
  Scenario: Going to the page /resolve/Coriell:ND24213 will forward to /model/Coriell:ND24213
     Given I go to page "/resolve/Coriell:ND24213"

--- a/tests/behave/maui_phenogrid.feature
+++ b/tests/behave/maui_phenogrid.feature
@@ -14,16 +14,12 @@ Scenario: Documentation example phenogrid appears
    Given I go to page "/page/phenogrid"
     then the title should be "Monarch Phenotype Grid Widget"
 
-# Disabled until the CORS issue is fixed on beta.monarchinitiative.org for the /simsearch route:
-#   [Error] XMLHttpRequest cannot load http://beta.monarchinitiative.org/simsearch/phenotype.
-#   Origin http://localhost:8080 is not allowed by Access-Control-Allow-Origin. (index.html, line 0)
-#
-# @ui
-# Scenario: Loading the iframe content for Monarch Phenotype Grid Widget loads a page with the correct title
-#    Given I go to slow page "/node_modules/phenogrid/index.html" and wait for id "pg_svg_area"
-#      then the title should be "Monarch Phenotype Grid Widget"
-#      and the document should contain "Phenogrid is a Javascript component that visualizes"
-#      and the document should contain "Phenotype Comparison (grouped by Mus musculus genes)"
-#      and the document should contain "Fluctuations in consciousness"
-#      and the document should contain "Bahcc1"
+@ui
+Scenario: Loading the iframe content for Monarch Phenotype Grid Widget loads a page with the correct title
+   Given I go to slow page "/node_modules/phenogrid/index.html" and wait for id "pg_svg_area"
+     then the title should be "Monarch Phenotype Grid Widget"
+     and the document should contain "Phenogrid is a Javascript component that visualizes"
+     and the document should contain "Phenotype Comparison (grouped by Mus musculus genes)"
+     and the document should contain "Fluctuations in consciousness"
+     and the document should contain "Bahcc1"
 


### PR DESCRIPTION
Converts more routes in webapp.js to dual-mode (Ringo/Node)

Disables loadBlogData() for landing pages other than the home page.

Improves error page (and page not found) handling for NodeJS.

Adds behave tests for Error and PageNotFound.

Fixes /resolve endpoint behave test to match the behavior of /resolve on
RRID:xxxx identifiers.

Enables the Phenogrid behave test that was disabled due to CORS issues.

Fixes bug in NodeJS handling of getParam() during POSTs, so that the
request.payload field of HapiJS is used.
