### PR TITLE
Ready for Review and Merge. More unit tests, all routes converted to dual-mode. Lots of code cleanup.

### DIFF
--- a/MakefileNode
+++ b/MakefileNode
@@ -1,0 +1,149 @@
+####
+#### Development easing.
+####
+
+###
+### Environment variables.
+###
+
+## NodeJS
+NODE_PATH ?= ./node-modules:./modules:./lib/monarch
+## TODO/BUG: highly non-canonical location--should be passed as
+## variable, not hard-coded.
+NODE_BIN ?= $(shell which node)
+## Workaround for the above.
+NODE_CLI_BIN ?= $(shell which node)
+NODE_PORT ?= 8080
+
+test:
+	echo "NODE_BIN: ${NODE_BIN}"
+	NODE_PATH=$(NODE_PATH) $(NODE_BIN) tests/apitest.js
+
+## OWLTools.
+#OWLTOOLS_MAX_MEMORY ?= 1G
+OWLTOOLS_BIN ?= ~/local/src/svn/owltools/OWLTools-Runner/bin/owltools
+
+## Version
+MONARCH_VERSION = 0.1.1
+
+###
+### Tests
+###
+
+APITESTS = apitest literature-test class-info-test
+TESTS = $(APITESTS) urltester
+
+xtest: $(patsubst %, test-%, $(TESTS))
+xapitest: $(patsubst %, test-%, $(APITESTS))
+xproduction-test: $(patsubst %, production-test-%, $(TESTS))
+
+test-%:
+	NODE_PATH=$(NODE_PATH) $(NODE_BIN) tests/$*.js
+
+production-test-%:
+	NODE_PATH=$(NODE_PATH) $(NODE_BIN) tests/$*.js -s production
+
+nif-production-url-test:
+	NODE_PATH=$(NODE_PATH) $(NODE_BIN) tests/urltester.js -s production -c vocabulary,ontoquest,federation,monarch
+
+nif-production-federation-tests:
+	NODE_PATH=$(NODE_PATH) $(NODE_BIN) tests/urltester.js -s production -c federation
+
+nif-production-scigraph-tests:
+	NODE_PATH=$(NODE_PATH) $(NODE_BIN) tests/urltester.js -s production -c scigraph
+
+nif-production-federation-search-tests:
+	NODE_PATH=$(NODE_PATH) $(NODE_BIN) tests/urltester.js -s production -c federation-search
+
+D2T_YAMLS = $(wildcard conf/rdf-mapping/*.yaml)
+D2T_JSONS = $(D2T_YAMLS:.yaml=.json)
+
+d2t: $(D2T_JSONS)
+	echo YAMLS: $^
+
+triples: conf/monarch-context.jsonld d2t
+#	NODE_PATH=$(NODE_PATH) $(NODE_BIN) bin/generate-triples-from-nif.js -c conf/server_config_production.json $(D2T_ARGS) conf/rdf-mapping/*-map.json && ./bin/target-ttl-to-owl.sh
+	NODE_PATH=$(NODE_PATH) $(NODE_BIN) bin/generate-triples-from-nif.js -c conf/server_config_dev.json $(D2T_ARGS) conf/rdf-mapping/*-map.json && ./bin/target-ttl-to-owl.sh
+
+#SERVERCONF := production
+SERVERCONF := dev
+target/%.ttl: conf/rdf-mapping/%-map.json conf/monarch-context.jsonld
+	NODE_PATH=$(NODE_PATH) $(NODE_BIN) bin/generate-triples-from-nif.js -c conf/server_config_$(SERVERCONF).json $<
+
+target/%.owl: target/%.ttl
+	owltools $< --set-ontology-id http://purl.obolibrary.org/obo/upheno/data/$*.owl -o -f ofn target/$*.owl 
+
+# TEMP
+#conf/rdf-mapping/%.yaml: conf/rdf-mapping/%.json
+#	json2yaml.pl $< > $@.tmp && mv $@.tmp $@
+
+YAML2JSON = yaml2json.pl
+##YAML2JSON = python yaml2json.py
+
+conf/rdf-mapping/%.json: conf/rdf-mapping/%.yaml
+	yaml2json.pl $< > $@.tmp && mv $@.tmp $@
+
+conf/monarch-context.jsonld: conf/monarch-context.yaml
+	yaml2json.pl $< > $@.tmp && mv $@.tmp $@
+
+###
+### Compile the Solr schema and JSON config out of the YAML files.
+###
+
+solr-schema: ./conf/golr-views/*-config.yaml
+	$(OWLTOOLS_BIN) --solr-config $? --solr-schema-dump | ./scripts/remove-schema-cruft.pl > ./conf/schema.xml
+
+.PHONY: golr-conf-as-json
+golr-conf-as-json: ./conf/golr-conf.json
+./conf/golr-conf.json: ./conf/golr-views
+	./scripts/confyaml2json.pl -i $< > $@.tmp && mv $@.tmp $@
+
+reconfigure-golr: solr-schema golr-conf-as-json
+
+###
+### Documentation.
+###
+
+.PHONY: docs
+docs:
+	naturaldocs --rebuild-output --input lib/monarch --project lib/.naturaldocs_project/ --output html docs/
+
+###
+### Create exportable JS bundle.
+###
+
+.PHONY: bundle
+bundle:
+	./scripts/release-js.pl -v -i scripts/release-file-map.txt -o js/monarch.js -n monarch -d js -r $(MONARCH_VERSION)
+
+###
+### Deployment.
+###
+
+deploy: origin-push heroku-deploy
+
+origin-push:
+	git push origin master
+
+## cjm: http://secret-harbor-1370.herokuapp.com/
+heroku-create:
+	heroku create --stack cedar --buildpack https://github.com/cmungall/heroku-buildpack-ringojs-jdk7.git --remote monarch-heroku
+heroku-deploy:
+	git push monarch-heroku master
+
+app-engine:
+	ringo-admin create --google-appengine gae
+
+dependencies:
+	sh ./update_dependencies.sh
+
+## Setup portable Ubuntu environment. -SJC
+.PHONY: cli-launch-prod
+cli-launch-prod: dependencies
+	NODE_PATH=$(NODE_PATH) $(NODE_CLI_BIN) ./lib/monarch/web/webapp_launcher_production.js --port=$(NODE_PORT)
+.PHONY: cli-launch-dev
+cli-launch-dev: dependencies
+	NODE_PATH=$(NODE_PATH) $(NODE_CLI_BIN) ./lib/monarch/web/webapp_launcher_dev.js --port=$(NODE_PORT)
+.PHONY: cli-launch
+cli-launch: dependencies
+	NODE_PATH=$(NODE_PATH) $(NODE_CLI_BIN) ./lib/monarch/web/webapp_launcher.js --port=$(NODE_PORT)

--- a/README.md
+++ b/README.md
@@ -2,33 +2,39 @@
 
 ## About
 
-This repo contains the JS API and RingoJS application to drive the Monarch Initiative web interface.
+This repo contains the JS API and web application to drive the Monarch Initiative web interface.
 
 You can run the website locally (see below).
 
 The live version of the Monarch Initiative web interface is at [http://monarchinitiative.org](http://monarchinitiative.org).
 
+### Transitioning RingoJS vs NodeJS
+
+The Monarch Initiative web application server is being migrated from the RingoJS server-side Javascript framework to a NodeJS framework. The current version of Monarch is still based upon RingoJS, which uses the Rhino Javascript engine within a Java Virtual Machine. The same Javascript source code that implements Monarch is now able to run under NodeJS, although we are still performing tests and quality assurance before we migrate completely to NodeJS. The instructions below refer to the RingoJS implementation unless otherwise clarified as NodeJS-specific.
+
 ## Quickstart
 
-Just type
+After downloading the Monarch GitHub repository, change your working directory to the downloaded source code and then type:
 
     ./install.sh
 
-Then start the server:
+This will install the required modules, including NPM-based modules such as `gulp` and `mustache`, as well as the necessary RingoJS runtime.
+
+After installation completes, start the server:
 
     ./start-server.sh
 
-You're done!
+You're done! You now have a running Monarch Initiative web application.
 
-Connect on localhost:
+Try it out by connecting your browser to:
 
  * http://127.0.0.1:8080/
 
-Or a particular disease, e.g:
+Or view a particular disease, e.g:
 
  * http://127.0.0.1:8080/disease/DOID_14692
 
-## Alternate installation instructions
+### Manual RingoJS installation and launch instructions
 
 1. Install RingoJS - http://ringojs.org
 
@@ -44,15 +50,15 @@ Or a particular disease, e.g:
 
 Monarch-app includes a home-grown widget framework for including
 functionality components that are required for the operation of the
-monarch-app, but not included in the monarch-app distribution. 
+monarch-app, but not included in the monarch-app distribution.
 
 Currently, there is only one such widget - the [phenogrid
-browser](https://github.com/monarch-initiative/phenogrid). 
+browser](https://github.com/monarch-initiative/phenogrid).
 
 Monarch-app will clone this repository into an appropriate location -
 ./widgets/phenogrid - upon installation. The phenogrid code will be
 updated via a pull upon start of the process.  These steps will be
-managed via the update_dependencies.sh script. 
+managed via the update_dependencies.sh script.
 
 Note that the .gitignore file explicitly ignores these components that
 are pulled in separately.

--- a/lib/monarch/api.js
+++ b/lib/monarch/api.js
@@ -29,6 +29,7 @@ if (!env.isRingoJS()) {
 var bbop = require('bbop');
 if (typeof bbop == 'undefined') { var bbop = {};}
 if (typeof bbop.monarch == 'undefined') { bbop.monarch = {};}
+exports.bbop = bbop;
 
 
 // ========================================
@@ -50,18 +51,18 @@ if (typeof bbop.monarch == 'undefined') { bbop.monarch = {};}
 bbop.monarch.Engine = function(opts) {
     if (bbop.monarch.defaultConfig != null) {
         this.config = bbop.monarch.defaultConfig;
-        this.log("Using pre-set configuration: ");
+        this.log("bbop.monarch.Engine Using pre-set configuration: ");
     }
     else {
-        this.log("Using default configuration");
+        this.log("bbop.monarch.Engine Using default configuration");
         this.config = {};
     }
     
     if (bbop.monarch.golrConfig != null) {
         this.config.golr = bbop.monarch.golrConfig;
-        this.log("Using pre-set golr configuration: ");
+        this.log("bbop.monarch.Engine Using pre-set golr configuration: ");
     } else {
-        this.log("WARN: No GOlr configuration set");
+        this.log("bbop.monarch.Engine WARN: No GOlr configuration set");
     }
     
     // set defaults
@@ -120,14 +121,12 @@ bbop.monarch.Engine = function(opts) {
         };
     }
 
-    var subprocess = env.isRingoJS() ? require('ringo/subprocess') : null;
-
-    this.debugInfo = 
+    this.debugInfo =
         {
             dateServerStarted : new Date(Date.now()),
             serverInfo :
                 env.isRingoJS() ?
-                    subprocess.command("uname -a")
+                    require('ringo/subprocess').command("uname -a")
                     :
                     require("child_process").exec('uname -a').unref(),
             apiVersionInfo : this.apiVersionInfo(),
@@ -535,6 +534,7 @@ bbop.monarch.Engine.prototype.getInfoProfileFromAssociations = function(assocs) 
  * Returns: JSON blob with info about the phenotype
  */
 bbop.monarch.Engine.prototype.fetchPhenotypeInfo = function(id, opts) {
+    var engine = this;
     //this.log("Phenotype: "+id);
     if (this.cache != null) {
         var cached = this.cache.fetch('phenotype', id);
@@ -1606,7 +1606,6 @@ bbop.monarch.Engine.prototype.fetchLiteratureInfo = function(id) {
 
 bbop.monarch.Engine.prototype.fetchOrthologList = function(ids) {
     var engine = this;
-    
     ids = engine.unique(ids);
     
     var results = {
@@ -1890,6 +1889,7 @@ bbop.monarch.Engine.prototype.fetchGeneOrthologAsAssociation = function(id,label
 
 bbop.monarch.Engine.prototype.trVariant = function(r,variant_type) {
     var variant = {};
+    var engine = this;
     variant.id = r[variant_type+"_id"];
     if (typeof variant.id != 'undefined') {
         if (/^OMIM/.test(variant.id)) {
@@ -2055,6 +2055,7 @@ bbop.monarch.Engine.prototype.fetchGeneAlleleAsAssociation = function(id,genObj,
  * 
  */
 bbop.monarch.Engine.prototype.fetchGeneGenoTypeAsAssociation = function(id,source, genObj) {
+    var engine = this;
     var source_to_resource_map = {    // HARDCODE ALERT
             'WB'    : {id:'nif-0000-00053-3',label:'WB'},      // WB
             'MGI'   : {id:'nif-0000-00096-5',label:'MGI'},    // MGI
@@ -2569,12 +2570,11 @@ bbop.monarch.Engine.prototype.fetchOmimDiseasePhenotypeAsAssocations = function(
                 resource.id,
                 trOmim,
                 null,
-        null,
+                null,
                 filters,
-        subclassFilters
+                subclassFilters
                 );
 
-    this.log("Phenos:"+JSON.stringify(resultObj));
     return resultObj;
 }
 
@@ -3837,6 +3837,7 @@ bbop.monarch.Engine.prototype.fetchRelatedDrugs = function(id) {
 bbop.monarch.Engine.prototype.fetchMonarchIntegratedDiseaseModels = function(id) {
     var resource_id = 'nlx_152525-2'; // HARCODE ALERT
 
+    var engine = this;
     // translate
     var tr =
         function (r) {
@@ -3918,7 +3919,7 @@ bbop.monarch.Engine.prototype.getInformationProfile = function(annotation_profil
         return scored_profile;
     }
 
-    this.log("CATEGORIES:"+JSON.stringify(categories));    
+    // this.log("CATEGORIES:"+JSON.stringify(categories));    
     // loop through all of the features, and build the params for owlsim
     // make sure to split them into norm/abnorm (isPresent = true|false)
     // i am only taking phenotypes, not the metadata
@@ -4997,7 +4998,7 @@ bbop.monarch.Engine.prototype.fetchPhenotypes = function(id,pathtype) {
     var params = {  };  //none
     var pathsuffix = '/phenotypes/targets';
     var path = pathprefix+id+pathsuffix;
-    var resultObject = engine.querySciGraphDynamicServices(path);
+    var resultObject = this.querySciGraphDynamicServices(path);
     var nodes = [];
     if (typeof resultObject.nodes != 'undefined') {
         nodes = resultObject.nodes;
@@ -6029,10 +6030,9 @@ bbop.monarch.Engine.prototype.annotateText = function(txt, opts) {
     if (!opts || !'longestOnly' in opts || !opts.longestOnly){
         opts.longestOnly = 'false';
     }
-    var annotate_url = engine.config.scigraph_url + "annotations/entities.json";
+    var annotate_url = this.config.scigraph_url + "annotations/entities.json";
     var res = 
         this.fetchUrl(annotate_url, q); 
-    this.log(res);    
     var results = JSON.parse(res);
     results.forEach(function(r) {
         if (r.token.id != null) {
@@ -6486,7 +6486,7 @@ bbop.monarch.Engine.prototype.fetchSimilarPapersFromPMID = function(id) {
 bbop.monarch.Engine.prototype.fetchDataDescriptions = function() {
 
     var t="resource_data_descriptions";
-    var sources = JSON.parse(env.fs_readFileSync('conf/'+t+'.json'));
+    var sources = env.readJSON('conf/'+t+'.json');
 
     //convert categories and ontologies to arrays
     for (var i=0;i<sources.length; i++) {
@@ -6590,13 +6590,19 @@ bbop.monarch.Engine.prototype.fetchUrl = function(url, params, method) {
  * 
  * Returns: Exchange object
  */
+
+var logFetchTimes = true;
 bbop.monarch.Engine.prototype.fetchUrlWithExchangeObject = function(url, params, method) {
     var data = '';
     if (params == null) {
         params = {};
     }
-    var timeDelta = Date.now();
-    this.log("FETCHING: " + method + " " +url+" params="+JSON.stringify(params));
+
+    if (logFetchTimes) {
+        var timeDelta = Date.now();
+        this.log("FETCHING: " + method + " " +url+" params="+JSON.stringify(params));
+    }
+
     this._lastURL = url;
     var exchangeObj;
     if (env.isRingoJS()) {
@@ -6635,23 +6641,36 @@ bbop.monarch.Engine.prototype.fetchUrlWithExchangeObject = function(url, params,
         };
     }
 
-    timeDelta = Date.now() - timeDelta;
-    // var g = env.isRingoJS() ? global : this;
-    // if (g._timingRequestCount) {
-    //   g._timingRequestCount = g._timingRequestCount + 1;
-    //   g._timingRequestTime = g._timingRequestTime + timeDelta;
-    //   g._timingRequestLength = g._timingRequestLength + exchangeObj.content.length;
-    // }
-    // else {
-    //   g._timingRequestCount = 1;
-    //   g._timingRequestTime = timeDelta;
-    //   g._timingRequestLength = exchangeObj.content.length;
-    // }
-    this.log("FETCHED status: " + exchangeObj.status + "  Length: " + exchangeObj.content.length + "  Time: " +
-        timeDelta + "ms");
-    //     // "  Total #" + g._timingRequestCount +
-    //     // "  Total Time: " + g._timingRequestTime +
-    //     // "  Total Length: " + g._timingRequestLength);
+    if (logFetchTimes) {
+        timeDelta = Date.now() - timeDelta;
+        var g;
+        if (env.isRingoJS()) {
+            g = module.singleton('monarchAPITiming',
+                function () { return {
+                                    _timingRequestCount: 0,
+                                    _timingRequestTime: 0,
+                                    _timingRequestLength: 0
+                                };
+                 });
+        }
+        else {
+            g = this;
+            if (typeof(g._timingRequestCount) === 'undefined') {
+                g._timingRequestCount = 0;
+                g._timingRequestTime = 0;
+                g._timingRequestLength = 0;
+            }
+        }
+
+        g._timingRequestCount = g._timingRequestCount + 1;
+        g._timingRequestTime = g._timingRequestTime + timeDelta;
+        g._timingRequestLength = g._timingRequestLength + exchangeObj.content.length;
+        this.log("FETCHED status: " + exchangeObj.status + "  Length: " + exchangeObj.content.length + "  Time: " +
+            timeDelta + "ms" +
+            "  Total #" + g._timingRequestCount +
+            "  Total Time: " + g._timingRequestTime +
+            "  Total Length: " + g._timingRequestLength);
+    }
 
     return exchangeObj;
 }
@@ -6758,7 +6777,8 @@ bbop.monarch.Engine.prototype.collapseEquivalencyClass = function(resultObj,uniq
     var unique = {};
     var count = 0;
     var sciGraphCache = {};
-    
+    var engine = this;
+
     //Required vars, if not passed return resultObj
     if (!uniqOnKeys || !colOnClass){
         return resultObj;
@@ -7148,7 +7168,7 @@ bbop.monarch.Engine.prototype.expandIdToURL = function(id) {
 }
 
 bbop.monarch.Engine.prototype.getConfig = function(t) {
-    var s = JSON.parse(env.fs_readFileSync('conf/'+t+'.json'));
+    var s = env.readJSON('conf/'+t+'.json');
     return s;
 }
 
@@ -7499,7 +7519,7 @@ bbop.monarch.Engine.prototype.fetchAssociations = function(id, field, filter, li
 }
 
 bbop.monarch.Engine.prototype.fetchAssociationCount = function(id, field, filter, facet) {
-    var golrResponse = engine.fetchAssociations(id, field, filter, 0, null, facet);
+    var golrResponse = this.fetchAssociations(id, field, filter, 0, null, facet);
     var count = 0;
     if (facet != null){
         var facet_list = golrResponse.facet_field(facet);
@@ -7698,6 +7718,7 @@ bbop.monarch.Engine.prototype.fetchDataInfo = function(id, opts) {
 //Hack to get patient pages, will eventually go away in favor of getting this info from a golr document
 bbop.monarch.Engine.prototype.fetchPatientInfo = function(id) {
     var info = {};
+    var engine = this;
     var neighbors = engine.getGraphNeighbors(id,1, undefined, undefined, true, engine.config.scigraph_data_url);
     info.diseases = [];
     info.genotypes = [];

--- a/lib/monarch/serverenv.js
+++ b/lib/monarch/serverenv.js
@@ -2,6 +2,7 @@
 function isRingoJS() {
   return (typeof(org) != 'undefined' && typeof(org.ringo) != 'undefined' );
 }
+
 var fs = require('fs');
 var fs_existsSync = isRingoJS() ?
                         function(path) {
@@ -68,7 +69,12 @@ var fs_unlinkSync = isRingoJS() ?
                           return fs.unlinkSync(path);
                         };
 
+function readJSON(filename) {
+  return JSON.parse(fs_readFileSync(filename));
+}
+
 exports.isRingoJS = isRingoJS;
+exports.readJSON = readJSON;
 exports.fs_existsSync = fs_existsSync;
 exports.fs_readFileSync = fs_readFileSync;
 exports.fs_readFileSyncBinary = fs_readFileSyncBinary;

--- a/lib/monarch/web/stickloader.js
+++ b/lib/monarch/web/stickloader.js
@@ -1,0 +1,12 @@
+//
+//	This JS file is specified by webapp.js during its initialization of the
+//	ringo/httpserver to declare a RingoJS module that will be loaded into
+//	each of the httpserver's worker threads.
+//	This file allows us to initialize the bbop.monarch.Engine and related structures
+//	that are needed in each worker thread.
+//
+var webapp = require('web/webapp.js');
+
+webapp.startServer();
+
+exports.app = webapp.app;

--- a/lib/monarch/web/webapp.js
+++ b/lib/monarch/web/webapp.js
@@ -1,17 +1,92 @@
  /*
+    Monarch WebApp
 
-   Monarch WebApp
+    This file is primarily about declaring http routes and handlers for the
+    Monarch web application.
 
-  See the RingoJS and Stick documentation for details on the approach.
 
-  After some helper functions are declared, this consists of mappings of URL patterns to queries + visualization
+    Migrating from RingoJS/Stick to NodeJS/HapiJS
+
+        The original Monarch web application was written assuming a RingoJS
+        execution environment, with the use of the Stick module to handle URL
+        routing. Most of the routes defined here have been converted from
+        their original RingoJS/Stick format into a format that also works with
+        NodeJS/HapiJS. These converted route definitions use a set of wrapper
+        functions in webenv.js to detect whether the runtime environment
+        (Ringo vs Node) and to use the appropriate environment-specific route
+        definition.
+
+        To ensure that the source code continues to work with both platforms,
+        please use the wrapper functions in serverenv.js and webenv.js.
+
+
+    Example dual-mode handler:
+        //
+        // Notice we are declaring both a stick-compatible path (/page/:page)
+        // and a Hapi-compatible path (/page/{page}). In addition, we provide
+        // an array of parameter names that will be used to extract values from
+        // the request and apply them as arguments to the handler function.
+        //
+        web.wrapRouteGet(app, '/page/:page', '/page/{page}', ['page'],
+            function(request, page) {
+                var info = {};
+                addCoreRenderers(info);
+
+                if ((page !== 'software')){
+                    info.pup_tent_css_libraries.push("/tour.css");
+                } else {
+                    info.pup_tent_css_libraries.push("/monarch-main.css");
+                }
+
+                var output = pup_tent.render(page+'.mustache',info);
+                return web.wrapHTML(output);
+            }
+        );
 
  */
 
-var env = require('../serverenv.js');
-var web = require('./webenv.js');
+var env = require('serverenv.js');
+var web = require('web/webenv.js');
 var fs = require('fs');
 var Mustache = require('mustache');
+
+var bbop = require('../api.js').bbop;
+
+// A prior version of Monarch used RingoJS' load() to inline the definitions
+// into this namespace. These var definitions are here to avoid a mass of git diffs
+// that would be caused by replacing every occurrence of genHRef with widgets.genHRef.
+//
+var widgets = require('./widgets.js');
+var     genObjectHref = widgets.genObjectHref;
+var     genURL = widgets.genURL;
+var     genExternalHref = widgets.genExternalHref;
+var     genOverviewOfGenotype = widgets.genOverviewOfGenotype;
+var     genTableOfSearchResults = widgets.genTableOfSearchResults;
+var     genTableOfAnalysisSearchResults = widgets.genTableOfAnalysisSearchResults;
+var     genTableOfAnnotateTextResults = widgets.genTableOfAnnotateTextResults;
+var     genTableOfDataSources = widgets.genTableOfDataSources;
+var     genTableOfDiseaseAlleleAssociations = widgets.genTableOfDiseaseAlleleAssociations;
+var     genTableOfDiseaseGeneAssociations = widgets.genTableOfDiseaseGeneAssociations;
+var     genTableOfDiseaseModelAssociations = widgets.genTableOfDiseaseModelAssociations;
+var     genTableOfDiseasePathwayAssociations = widgets.genTableOfDiseasePathwayAssociations;
+var     genTableOfDiseasePhenotypeAssociations = widgets.genTableOfDiseasePhenotypeAssociations;
+var     genTableOfDiseasePhenotypeAssociations = widgets.genTableOfDiseasePhenotypeAssociations;
+var     genTableOfGeneAlleleAssociations = widgets.genTableOfGeneAlleleAssociations;
+var     genTableOfGeneDiseaseAssociations = widgets.genTableOfGeneDiseaseAssociations;
+var     genTableOfGeneGenotypeAssociations = widgets.genTableOfGeneGenotypeAssociations;
+var     genTableOfGeneInteractionAssociations = widgets.genTableOfGeneInteractionAssociations;
+var     genTableOfGeneOrthologAssociations = widgets.genTableOfGeneOrthologAssociations;
+var     genTableOfGenePathwayAssociations = widgets.genTableOfGenePathwayAssociations;
+var     genTableOfGenePhenotypeAssociations = widgets.genTableOfGenePhenotypeAssociations;
+var     genTableOfGeneXRefs = widgets.genTableOfGeneXRefs;
+var     genTableOfGenotypePhenotypeAssociations = widgets.genTableOfGenotypePhenotypeAssociations;
+var     genTableOfGenoVariantAssociations = widgets.genTableOfGenoVariantAssociations;
+var     genTableOfLiterature = widgets.genTableOfLiterature;
+var     genTableOfLiteratureGenes = widgets.genTableOfLiteratureGenes;
+var     genTableOfSimilarDiseases = widgets.genTableOfSimilarDiseases;
+var     genTableOfSimilarModels = widgets.genTableOfSimilarModels;
+var     genTableOfSimilarPapers = widgets.genTableOfSimilarPapers;
+
 
 if (env.isRingoJS()) {
   var stick = require('stick');
@@ -27,6 +102,7 @@ else {
 }
 
 
+// Still ironing out the kinks on RingosJS vs NodeJS paths, hence this conditional
 if (env.isRingoJS()) {
   var pup_tent_loader = require('pup-tent');
   var reporter = require('pup-analytics')();
@@ -61,22 +137,15 @@ var pup_tent = pup_tent_loader([
                     ]);
 
 
-function expandTemplate(tmplName, tmplInfo) {
-    var result = pup_tent.apply( 'templates/' +  tmplName + '.mustache', tmplInfo);
-    // console.log('========= EXPAND ' + tmplName + ' Length:' + result.length + ' =========');
-    // console.log(result);
-    // console.log('======================================================================');
-    return result;
-}
-
+var app;
 
 if (env.isRingoJS()) {
-    var app = exports.app = new stick.Application();
+    app = exports.app = new stick.Application();
     app.configure('route');
     app.configure('params');
     app.configure('static');
-    app.configure(require('./sanitize'));
-    app.configure(require('./cors-middleware.js'));
+    app.configure(require('web/sanitize'));
+    app.configure(require('web/cors-middleware.js'));
 
     var http = require("ringo/utils/http");
     var isFileUpload = http.isFileUpload;
@@ -142,9 +211,10 @@ if (env.isRingoJS()) {
 else {
     var Hapi = require('hapi');
     var http = require('http');
+    var Inert = require('inert');
 
     // Create a server with a host and port
-    var app = new Hapi.Server();
+    app = new Hapi.Server();
     app.connection({
         host: 'localhost',
         port: 8080,
@@ -154,77 +224,7 @@ else {
             }
         }
     });
-
-    // Add routes
-
-    app.route({
-        method: 'GET',
-        path: '/js/{filename}',
-        handler: {
-            file: function (request) {
-                console.log('serving static:', '/js/' + request.params.filename);
-                return 'js/' + request.params.filename;
-            }
-        }
-    });
-
-    // More efficient than fs.readFileSync(), presumably
-    // app.route({
-    //     method: 'GET',
-    //     path: '/image/{filename}',
-    //     handler: {
-    //         file: function (request) {
-    //             console.log('serving static:', '/image/' + request.params.filename);
-    //             return 'image/' + request.params.filename;
-    //         }
-    //     }
-    // });
-
-    app.route({
-        method: 'GET',
-        path: '/css/{filename}',
-        handler: {
-            file: function (request) {
-                console.log('serving static:', '/css/' + request.params.filename);
-                return 'css/' + request.params.filename;
-            }
-        }
-    });
-
-    app.start(function () {
-        console.log('Server running at:', app.info.uri);
-    });
-
-    app.get = function (route, handler) {
-        var simpleRoute = route.indexOf(':') === -1;
-        var wrappedHandler =  function (request, reply) {
-                                WaitFor.launchFiber(handler, request, reply);
-                              };
-        if (simpleRoute) {
-            app.route({
-                method: 'GET',
-                path: route,
-                handler: wrappedHandler
-            });
-        }
-        else {
-            //console.log('#### PARAMETERIZED ROUTES NOT YET IMPLEMENTED:', route);
-        }
-    };
-
-    app.post = function (route, handler) {
-        var wrappedHandler =  function (request, reply) {
-                                WaitFor.launchFiber(handler, request, reply);
-                              };
-        var simpleRoute = route.indexOf(':') === -1;
-        if (simpleRoute) {
-            app.route({
-                method: 'POST',
-                path: route,
-                handler: wrappedHandler
-            });
-        }
-    };
+    app.register(Inert, function () {});
 }
 
 
@@ -248,9 +248,6 @@ pup_tent.set_common('js_libs', [
     '/jquery.cookie.js',
     '/jquery.xml2json.js']);
 
-
-//note: in future this may conform to CommonJS and be 'require'd
-var engine = new bbop.monarch.Engine();
 
 // The kinds of types that we're likely to see.
 var js_re = /\.js$/;
@@ -323,26 +320,39 @@ pup_tent.cached_list().forEach(
   });
 
 
-// When not in production, re-read files from disk--makes development
-// easier.
-if( ! engine.isProduction() ){
-    pup_tent.use_cache_p(false);
-}
+//
+// The buildEngine helper function allows us to defer the construction
+// of the bbop and MonarchAPI objects until we know the proper configs, which
+// are set via app.configServer.
+//
+function buildEngine(defaultConfig, golrConfig) {
+    bbop.monarch.defaultConfig = defaultConfig;
+    bbop.monarch.golrConfig = golrConfig;
+    var engine = new bbop.monarch.Engine();
 
-// note: this will probably move to it's own OO module
-engine.cache = {
+    // When not in production, re-read files from disk--makes development
+    // easier.
+    if( !engine.isProduction() ){
+        pup_tent.use_cache_p(false);
+    }
+
+    // note: this should probably move to it's own OO module
+    engine.cache = {
     fetch: function(tbl, key, val) {
         var result = null;
         var path = "./cache/"+tbl+"/key-"+key+".json";
         if (env.fs_existsSync(path)) {
-            var content = env.fs_readFileSync(path);
-            result = JSON.parse(content);
+            console.log('###CACHE HIT :', key);
+            result = env.readJSON(path);
+        }
+        else {
+            console.log('###CACHE MISS:', key);
         }
         return result;
     },
     store: function(tbl, key, val) {
         var path = "./cache/"+tbl+"/key-"+key+".json";
-        //console.log("S lookup:"+path);
+        console.log('###CACHE SAVE:', key);
         env.fs_writeFileSync(path, JSON.stringify(val));
     },
     clear: function(match) {
@@ -363,17 +373,26 @@ engine.cache = {
         }
     },
     sizeInfo: function() {
-        var subprocess = require("ringo/subprocess");
-        console.log("Getting sizeInfo for "+this.cacheDirs());
-        var info =
-            this.cacheDirs().map(function(dir) {
-                console.log("Testing: "+dir);
-                return { id : dir,
-                         entries : env.fs_listTreeSync("cache/"+dir).filter(function(f){ return f.indexOf(".json") > 0}).length,
-                         sizeOnfo : subprocess.command("du -sh cache/"+dir)
-                       };
-            });
-        console.log("Got: "+info.length);
+        if (env.isRingoJS()) {
+            var subprocess = require("ringo/subprocess");
+            console.log("Getting sizeInfo for "+this.cacheDirs());
+            var info =
+                this.cacheDirs().map(function(dir) {
+                    return { id : dir,
+                             entries : env.fs_listTreeSync("cache/"+dir).filter(function(f){ return f.indexOf(".json") > 0}).length,
+                             sizeOnfo : subprocess.command("du -sh cache/"+dir)
+                           };
+                });
+        }
+        else {
+            var info =
+                this.cacheDirs().map(function(dir) {
+                    return { id : dir,
+                             entries : env.fs_listTreeSync("cache/"+dir).filter(function(f){ return f.indexOf(".json") > 0}).length,
+                             sizeOnfo : ""
+                           };
+                });
+        }
         return info;
     },
     cacheDirs: function() {
@@ -388,14 +407,15 @@ engine.cache = {
     contents: function() {
         return env.fs_listTreeSync("cache").filter(function(f){ return f.indexOf(".json") > 0});
     }
-};
+    };
 
-// STATIC HELPER FUNCTIONS. May become OO later.
-//o Deprecated with Pup tent
-function getConfig(t) {
-    var s = JSON.parse(env.fs_readFileSync('conf/'+t+'.json'));
-    return s;
+    return engine;
 }
+
+
+// Declare 'engine' into scope now, give it a value later via buildEngine
+
+var engine;
 
 function staticTemplate(t) {
     var info = {};
@@ -428,6 +448,16 @@ function loadBlogData(category, lim) {
   }
   return blog_res;
 }
+
+
+function expandTemplate(tmplName, tmplInfo) {
+    var result = pup_tent.apply( 'templates/' +  tmplName + '.mustache', tmplInfo);
+    // console.log('========= EXPAND ' + tmplName + ' Length:' + result.length + ' =========');
+    // console.log(result);
+    // console.log('======================================================================');
+    return result;
+}
+
 
 // This function takes a json representation of some data
 // (for example, a disease and various associated genes, phenotypes)
@@ -495,7 +525,7 @@ function addCoreRenderers(info, type, id, defaults){
     if( info['conf']['monarch-team'] == null ){
     // Read in conf/monarch-team.json.
     info['conf']['monarch-team'] =
-        JSON.parse(env.fs_readFileSync('./conf/monarch-team.json'));
+        env.readJSON('./conf/monarch-team.json');
     }
 
     if (info.relationships != null) {
@@ -555,7 +585,8 @@ function addCoreRenderers(info, type, id, defaults){
 
     info.isProduction = engine.config.type == 'production';
 
-    info.alerts = info.alerts.concat(getConfig('alerts'));
+    var alertsConfig = env.readJSON('conf/alerts.json');
+    info.alerts = info.alerts.concat(alertsConfig);
     if (!info.isProduction) {
         var prodUrlSuffix = (id == null ? "" : genURL(type, id));
         var prodUrl = "http://monarchinitiative.org" + prodUrlSuffix;
@@ -710,13 +741,7 @@ web.wrapRouteGet(app, '/status', '/status', [],
     }
 );
 
-// Method: /
-//
-// Arguments:
-//  - none
-//
-// Returns:
-//  Top level page
+if (false) { /* Disabling all /legacy/xxx and /labs/xxx endpoints that aren't dual-mode */
 app.get('/labs/old-home', function(request) {
     var info = {};
     addCoreRenderers(info);
@@ -729,7 +754,7 @@ app.get('/labs/old-home', function(request) {
     var output = pup_tent.render('main.mustache', info, 'monarch_base.mustache');
     return response.html(output);
 });
-
+}
 
 web.wrapRouteGet(app, '/page/:page', '/page/{page}', ['page'],
     function(request, page) {
@@ -762,23 +787,27 @@ web.wrapRouteGet(app, '/robots.txt', '/robots.txt', [],
 
 // anything in the docs/ directory is passed through statically
 
-web.wrapRouteGet(app, '/docs/:dirname/:filename', '/docs/{dirname}/{filename}', ['dirname', 'filename'],
-    function(request, dirname, filename) {
-        var path = './docs/'+dirname + '/' + filename;
-        var ctype = _decide_content_type(path);
-        var s = env.fs_readFileSync(path) + '';
-        return web.wrapBinary(s, ctype);
+function docHandler(request, p1, p2, p3) {
+    var path = './docs';
+    if (p1) {
+        path += '/' + p1;
     }
-);
+    if (p2) {
+        path += '/' + p2;
+    }
+    if (p3) {
+        path += '/' + p3;
+    }
 
-web.wrapRouteGet(app, '/docs/:filename', '/docs/{filename*}', ['filename'],
-    function(request, filename) {
-        var path = './docs/'+filename;
-        var ctype = _decide_content_type(path);
-        var s = env.fs_readFileSync(path) + '';
-        return web.wrapHTML(s);
-    }
-);
+    var ctype = _decide_content_type(path);
+    var s = env.fs_readFileSync(path) + '';
+    return web.wrapBinary(s, ctype);
+}
+
+web.wrapRouteGet(app, '/docs/:p1/:p2/:p3', '/docs/{p1}/{p2}/{p3}', ['p1', 'p2', 'p3'], docHandler);
+web.wrapRouteGet(app, '/docs/:p1/:p2', '/docs/{p1}/{p2}', ['p1', 'p2'], docHandler);
+web.wrapRouteGet(app, '/docs/:p1', '/docs/{p1}', ['p1'], docHandler);
+
 
 web.wrapRouteGet(app, '/image/:page', '/image/{page}', ['page'],
     function(request, page) {
@@ -816,48 +845,6 @@ web.wrapRouteGet(app, '/node_modules/phenogrid/:filename', '/node_modules/phenog
     }
 );
 
-
-//
-//  Miscellaneous utility functions that should be moved out of the way of the route defs
-//
-/* needed to retain basic functionality for pass-through end run around puptent for phenogrid.*/
-function serveDirect(loc,page,ctype) {
-    // var body = env.fs_readFileSyncBinary(loc+'/'+page);
-    // var result = {
-    //         body: [body],
-    //         headers: {'Content-Type': ctype},
-    //         status: 200
-    //     };
-    var path = module.resolve('../../../' + loc+'/'+page);
-    var result = response.static(path, ctype);
-    return result;
-}
-
-
-// Get the query format (or null)
-function getQueryFormat(path) {
-  var fmt = null;
-  if (path.lastIndexOf('.') > -1) {
-      fmt = path.substring(path.lastIndexOf('.') + 1);
-      if (0 === fmt.length) {
-          fmt = null;
-      }
-  }
-  return fmt;
-}
-
-// Get the query term
-function getQueryTerm(path) {
-  if (path.lastIndexOf('.') > -1) {
-      path = path.substring(0, path.lastIndexOf('.'));
-  }
-  return path.substring(path.indexOf('/', 1) + 1);
-}
-
-
-//
-// Continue with route defs
-//
 
 // Method: search
 //
@@ -1002,7 +989,6 @@ function neurosearchHandler(request, term, fmt) {
     }
 }
 
-
 // Order matters here in the declaration of these routes.
 web.wrapRouteGet(app, '/neurosearch/:term.:fmt?', '/neurosearch/{term}.{fmt}', ['term', 'fmt'], neurosearchHandler);
 web.wrapRouteGet(app, '/neurosearch/:term', '/neurosearch/{term}', ['term'], neurosearchHandler);
@@ -1054,7 +1040,6 @@ web.wrapRouteGet(app, '/sources', '/sources', [], sourcesHandler);
 //
 // Returns:
 //  List of matching objects
-
 
 function autocompleteByCategoryTermHandler(request,category,term,fmt) {
     // todo - we would like to normalize possible categories; e.g. phenotype --> Phenotype
@@ -1170,7 +1155,7 @@ web.wrapRouteGet(app, '/disease', '/disease', [],
     info.pup_tent_js_variables.push({name:'global_scigraph_url',
         value: engine.config.scigraph_url});
     
-    var diseaseDist = JSON.parse(env.fs_readFileSync('./widgets/dove/stats/DO-cache.json'));
+    var diseaseDist = env.readJSON('./widgets/dove/stats/DO-cache.json');
     info.pup_tent_js_libraries.push("/dove.min.js");
     info.pup_tent_js_libraries.push("/d3.3.5.5.min.js");
     info.pup_tent_css_libraries.push("/dovegraph.css");
@@ -1188,6 +1173,7 @@ web.wrapRouteGet(app, '/disease', '/disease', [],
   });
 
 
+if (false) { /* Disabling all /legacy/xxx and /labs/xxx endpoints that aren't dual-mode */
 // DISEASE PAGE
 // Status: working but needs work
 app.get('/legacy/disease/:id.:fmt?', function(request, id, fmt) {
@@ -1334,6 +1320,8 @@ app.get('/legacy/disease/:id.:fmt?', function(request, id, fmt) {
     }
 
 });
+}
+
 
 // This function checks if a variable exists in the JSON blob (and is used to dynamically
 // render the Mustache templates.
@@ -1355,6 +1343,8 @@ function getNumLabel(variable) {
     }
 };
 
+
+if (false) { /* Disabling all /legacy/xxx and /labs/xxx endpoints that aren't dual-mode */
 // DISEASE - Sub-pages
 // Example: /disease/DOID_12798/phenotype_associations.json
 // Currently only works for json or rdf output
@@ -1379,6 +1369,8 @@ app.get('/legacy/disease/:id/:section.:fmt?', function(request, id, section, fmt
         return response.error("plain HTML does not work for page sections. Please append .json or .rdf to URL");
     }
 });
+}
+
 
 // Method: phenotype
 //
@@ -1464,7 +1456,7 @@ function phenotypeLandingHandler(request) {
     info.pup_tent_js_variables.push({name:'global_scigraph_url',
         value: engine.config.scigraph_url});
     
-    var phenoDist = JSON.parse(env.fs_readFileSync('./widgets/dove/stats/hp-ontology-4.json'));
+    var phenoDist = env.readJSON('./widgets/dove/stats/hp-ontology-4.json');
     info.pup_tent_js_libraries.push("/d3.3.5.5.min.js");
     info.pup_tent_css_libraries.push("/dovegraph.css");
     info.pup_tent_js_libraries.push("/dove.min.js");
@@ -1482,6 +1474,8 @@ function phenotypeLandingHandler(request) {
 
 web.wrapRouteGet(app, '/phenotype', '/phenotype', [], phenotypeLandingHandler);
 
+
+if (false) { /* Disabling all /legacy/xxx and /labs/xxx endpoints that aren't dual-mode */
 app.get('/legacy/phenotype/:id.:fmt?', function(request, id, fmt) {
 
     // TEMPORARY. Remove when this resolved: https://github.com/monarch-initiative/monarch-app/issues/246
@@ -1566,7 +1560,10 @@ app.get('/legacy/phenotype/:id.:fmt?', function(request, id, fmt) {
         return errorResponse(err);
     }
 });
+}
 
+
+if (false) { /* Disabling all /legacy/xxx and /labs/xxx endpoints that aren't dual-mode */
 // Note: currently both /genotype/ and /model/ direct here;
 // need to decide if we want these URLs to behave differently, or
 // to collapse/redirect
@@ -1652,6 +1649,43 @@ var fetchLegacyGenotypePage = function(request, id, fmt) {
         return errorResponse(err);
     }
 };
+
+
+
+
+
+// GENOTYPE - Sub-pages
+// Example: /genotype/MGI_4420313/genotype_associations.json
+// Currently only works for json or rdf output
+var fetchLegacyGenotypeSection =  function(request, id, section, fmt) {
+    var newId = engine.resolveClassId(id);
+    if (newId != id) {
+        engine.log("redirecting: "+id+" ==> "+newId);
+        return web.wrapRedirect(genURL('genotype',newId));
+    }
+
+    var info = engine.fetchGenotypeInfo(id);
+
+    var sectionInfo =
+        { id: "obo:"+id }; // <-- TODO - unify ID/URI strategy
+    sectionInfo[section] = info[section];
+    engine.addJsonLdContext(sectionInfo);
+
+    if (fmt != null) {
+        return formattedResults(sectionInfo, fmt,request);
+    }
+    else {
+        return response.error("plain HTML does not work for page sections. Please append .json or .rdf to URL");
+    }
+};
+
+// Status: STUB
+// this just calls the genotype page - TODO
+app.get('/legacy/genotype/:id.:fmt?', fetchLegacyGenotypePage);
+app.get('/legacy/model/:id.:fmt?', fetchLegacyGenotypePage);
+app.get('/legacy/genotype/:id./:section.:fmt?',fetchLegacyGenotypeSection);
+app.get('/legacy/model/:id/:section.:fmt?', fetchLegacyGenotypeSection);
+}
 
 
 function modelByIdHandler(request, id, fmt) {
@@ -1927,43 +1961,10 @@ web.wrapRouteGet(app, '/genotype/:id.:fmt?', '/genotype/{id}.{fmt}', ['id', 'fmt
 web.wrapRouteGet(app, '/genotype/:id', '/genotype/{id}', ['id'], genotypeByIdHandler);
 
 
-var genMGIXRef = function genMGIXRef(id){
+function genMGIXRef(id) {
     return "<a href=\"http://www.informatics.jax.org/allele/genoview/" +
             id + "\" target=\"_blank\">" + id + "</a>";
-};
-
-
-
-app.get('/legacy/genotype/:id.:fmt?', fetchLegacyGenotypePage);
-
-
-// GENOTYPE - Sub-pages
-// Example: /genotype/MGI_4420313/genotype_associations.json
-// Currently only works for json or rdf output
-var fetchLegacyGenotypeSection =  function(request, id, section, fmt) {
-    var newId = engine.resolveClassId(id);
-    if (newId != id) {
-        engine.log("redirecting: "+id+" ==> "+newId);
-        return web.wrapRedirect(genURL('genotype',newId));
-    }
-
-    var info = engine.fetchGenotypeInfo(id);
-
-    var sectionInfo =
-        { id: "obo:"+id }; // <-- TODO - unify ID/URI strategy
-    sectionInfo[section] = info[section];
-    engine.addJsonLdContext(sectionInfo);
-
-    if (fmt != null) {
-        return formattedResults(sectionInfo, fmt,request);
-    }
-    else {
-        return response.error("plain HTML does not work for page sections. Please append .json or .rdf to URL");
-    }
-};
-
-app.get('/legacy/genotype/:id./:section.:fmt?',fetchLegacyGenotypeSection);
-
+}
 
 
 function geneLandingPageHandler(request) {
@@ -2007,8 +2008,8 @@ function geneLandingPageHandler(request) {
     info.pup_tent_js_variables.push({name:'global_scigraph_url',
         value: engine.config.scigraph_url});
     
-    var phenoDist = JSON.parse(env.fs_readFileSync('./widgets/dove/stats/hp-ontology-4.json'));
-    var diseaseDist = JSON.parse(env.fs_readFileSync('./widgets/dove/stats/DO-cache.json'));
+    var phenoDist = env.readJSON('./widgets/dove/stats/hp-ontology-4.json');
+    var diseaseDist = env.readJSON('./widgets/dove/stats/DO-cache.json');
     info.pup_tent_js_libraries.push("/dove.min.js");
     info.pup_tent_js_libraries.push("/d3.3.5.5.min.js");
     info.pup_tent_css_libraries.push("/dovegraph.css");
@@ -2026,9 +2027,12 @@ function geneLandingPageHandler(request) {
     var output = pup_tent.render('gene_main.mustache', info,'monarch_base.mustache');
     return web.wrapHTML(output);
 }
+
 web.wrapRouteGet(app, '/gene', '/gene', [], geneLandingPageHandler);
 
 
+
+if (false) { /* Disabling all /legacy/xxx and /labs/xxx endpoints that aren't dual-mode */
 // Status: STUB
 app.get('/legacy/gene/:id.:fmt?', function(request, id, fmt) {
 
@@ -2129,6 +2133,8 @@ app.get('/legacy/gene/:id.:fmt?', function(request, id, fmt) {
     var output = pup_tent.render('gene-legacy.mustache',info,'monarch_base.mustache');
     return response.html(output);
 });
+}
+
 
 function modelLandingPageHandler(request){
     
@@ -2176,7 +2182,7 @@ function modelLandingPageHandler(request){
     
     
     //graph
-    var hpStub = JSON.parse(env.fs_readFileSync('./widgets/dove/stats/hp-ontology-4.json'));
+    var hpStub = env.readJSON('./widgets/dove/stats/hp-ontology-4.json');
     info.pup_tent_js_libraries.push("/d3.3.5.5.min.js");
     info.pup_tent_css_libraries.push("/dovegraph.css");
     info.pup_tent_js_libraries.push("/barchart-launcher.js");
@@ -2196,6 +2202,7 @@ function modelLandingPageHandler(request){
 web.wrapRouteGet(app, '/model', '/model', [], modelLandingPageHandler);
 web.wrapRouteGet(app, '/genotype', '/genotype', [], modelLandingPageHandler);
 
+
 function getGeneMapping(id) {
     var mappedID;
     var mappings = engine.mapGeneToNCBIgene(id);
@@ -2206,6 +2213,8 @@ function getGeneMapping(id) {
     return mappedID;
 }
 
+
+if (false) { /* Disabling all /legacy/xxx and /labs/xxx endpoints that aren't dual-mode */
 // GENE - Sub-pages
 // Example: /gene/NCIBGene:12166/phenotype_associations.json
 // Currently only works for json or rdf output
@@ -2231,6 +2240,7 @@ app.get('/legacy/gene/:id/:section.:fmt?', function(request, id, section, fmt) {
         return response.error("plain HTML does not work for page sections. Please append .json or .rdf to URL");
     }
 });
+}
 
 
 //For receiving of HPO relations for Phenogrid
@@ -2253,13 +2263,8 @@ web.wrapRouteGet(app, '/neighborhood/:id/:depth/:direction/:relationship', '/nei
 
 
 
-// Status: STUB
-// this just calls the genotype page - TODO
-app.get('/legacy/model/:id.:fmt?', fetchLegacyGenotypePage);
-app.get('/legacy/model/:id/:section.:fmt?', fetchLegacyGenotypeSection);
 
-
-
+if (false) { /* Disabling all /legacy/xxx and /labs/xxx endpoints that aren't dual-mode */
 // Status: STUB
 // note we hardcode this for now
 app.get('/phenome/Homo_sapiens.gff3', function(request, id, fmt) {
@@ -2273,6 +2278,7 @@ app.get('/phenome/Homo_sapiens.gff3', function(request, id, fmt) {
         status: 200
     };
 });
+}
 
 
 // Method: compare
@@ -2310,8 +2316,7 @@ app.get('/phenome/Homo_sapiens.gff3', function(request, id, fmt) {
 //  only one element will be found in "b".
 //  The resulting "combinedScore" is generated based on a perfect match of the query to itself.  Therefore, the reciprocal
 //  combined score may not be the same.  QxT !== TxQ.
-app.get('/compare/:x/:y.:fmt?', function(request, x, y, fmt) {
-    
+function compareHandler(request, x, y, fmt) {
     var xs = x.split("+");
     //first, split by comma.  then split by plus
     var ys = y.split(",");
@@ -2320,37 +2325,49 @@ app.get('/compare/:x/:y.:fmt?', function(request, x, y, fmt) {
     //pass the arrays
     var info = engine.compareEntities(xs,ys);
 
-    return response.json(info);
-});
+    return web.wrapJSON(info);
+}
+
+// Order matters here in the declaration of these routes.
+web.wrapRouteGet(app, '/compare/:x/:y.:fmt?', '/compare/{x}/{y}.{fmt}', ['x', 'y', 'fmt'], compareHandler);
+web.wrapRouteGet(app, '/compare/:x/:y', '/compare/{x}/{y}', ['x', 'y'], compareHandler);
+
 
 
 // Redirects
-app.get('/reference/:id.:fmt?', function(request, id, fmt) {
+function referenceByIdHandler(request, id, fmt) {
     //var info = engine.fetchReferenceInfo(id);  TODO
     //return web.wrapRedirect(engine.expandIdToURL(id));
     var url = makeExternalURL(id);
     return web.wrapRedirect(url);
-});
+}
 
-// STUB
-app.get('/publication/basic/:id.:fmt?', function(request, id, fmt) {
-    var info = engine.fetchReferenceInfo(id);  //TODO
-});
+// Order matters here in the declaration of these routes.
+web.wrapRouteGet(app, '/reference/:id.:fmt?', '/reference/{id}.{fmt}', ['id', 'fmt'], referenceByIdHandler);
+web.wrapRouteGet(app, '/reference/:id', '/reference/{id}', ['id'], referenceByIdHandler);
+
 
 //Get orthologs/paralogs
-app.get('/query/orthologs/:id.:fmt?', function(request, id, fmt) {
+function queryOrthologsByIdHandler(request, id, fmt) {
     var res;
     var idList = id.split("+");
     if (idList == '.json'){
-        res = response.error("No gene IDs entered")
+        res = errorResponse("No gene IDs entered")
     } else {
         var info = engine.fetchOrthologList(idList);
-        res = response.json(info);
+        res = web.wrapJSON(info);
     }
-    
-    return res;
-});
 
+    return res;
+}
+
+// Order matters here in the declaration of these routes.
+web.wrapRouteGet(app, '/query/orthologs/:id.:fmt?', '/query/orthologs/{id}.{fmt}', ['id', 'fmt'], queryOrthologsByIdHandler);
+web.wrapRouteGet(app, '/query/orthologs/:id', '/query/orthologs/{id}', ['id'], queryOrthologsByIdHandler);
+
+
+
+if (false) { /* Disabling all /legacy/xxx and /labs/xxx endpoints that aren't dual-mode */
 app.get('/legacy/variant/:id.:fmt?', function(request, id, fmt) {
     //since we don't have allele or variant pages,
     //we will redirect to the sources for now
@@ -2364,6 +2381,7 @@ app.get('/legacy/variant/:id.:fmt?', function(request, id, fmt) {
     engine.log("redirecting: "+id+" to source at "+url);
     return web.wrapRedirect(url);
 });
+}
 
 
 web.wrapRouteGet(app, '/class', '/class', [],
@@ -2448,7 +2466,6 @@ function anatomyByIdHandler(request, id, fmt) {
     return web.wrapHTML(output);
 }
 
-
 // Order matters here in the declaration of these routes.
 web.wrapRouteGet(app, '/anatomy/:id.:fmt?', '/anatomy/{id}.{fmt}', ['id', 'fmt'], anatomyByIdHandler);
 web.wrapRouteGet(app, '/anatomy/:id', '/anatomy/{id}', ['id'], anatomyByIdHandler);
@@ -2505,10 +2522,10 @@ function literatureByIdHandler(request, id, fmt) {
     return web.wrapHTML(output);
 }
 
-
 // Order matters here in the declaration of these routes.
 web.wrapRouteGet(app, '/literature/:id.:fmt?', '/literature/{id}.{fmt}', ['id', 'fmt'], literatureByIdHandler);
 web.wrapRouteGet(app, '/literature/:id', '/literature/{id}', ['id'], literatureByIdHandler);
+
 
 function getIdentifierList(params) {
     var input_items;
@@ -2527,14 +2544,14 @@ function getIdentifierList(params) {
 
 function itemsToArray(input_items) {
     input_items = input_items.split(/[\s,]+/);
-    engine.log("|Input| = "+input_items.length);
-    engine.log("Input: "+input_items);
+    // engine.log("|Input| = "+input_items.length);
+    // engine.log("Input: "+input_items);
     return input_items;
 }
 
 
 function mapStyleToCategories(style) {
-    engine.log("Mapping "+style+" to categories");
+    // engine.log("Mapping "+style+" to categories");
     //TODO: use external "style" files to map the style parameter to categories
     //for now, default to HPO categories
     var categories = [];
@@ -2604,11 +2621,9 @@ function simsearchDiseaseByIdHandler(request, id, fmt) {
     return web.wrapJSON(info.results);
 }
 
-
 // Order matters here in the declaration of these routes.
 web.wrapRouteGet(app, '/simsearch/disease/:id.:fmt?', '/simsearch/disease/{id}.{fmt}', ['id', 'fmt'], simsearchDiseaseByIdHandler);
 web.wrapRouteGet(app, '/simsearch/disease/:id', '/simsearch/disease/{id}', ['id'], simsearchDiseaseByIdHandler);
-
 
 
 function simsearchPhenotypeByTargetTypeLimitItemsHandler(request) {
@@ -2618,9 +2633,6 @@ function simsearchPhenotypeByTargetTypeLimitItemsHandler(request) {
     var limit = cutoff || web.getParam(request, 'limit') || 100;
     var input_items_a = web.getParam(request, 'a');
     var input_items = web.getParam(request, 'input_items');
-console.log('params:', Object.keys(request.params));
-console.log('input_items_a:', input_items_a);
-console.log('input_items:', input_items);
     input_items = input_items_a || itemsToArray(input_items);
 
     var target = null;
@@ -2630,11 +2642,11 @@ console.log('input_items:', input_items);
     return web.wrapJSON(info.results);
 }
 
-
 // web.wrapRouteGet(app, '/simsearch/phenotype', '/simsearch/phenotype', [], simsearchPhenotypeByTargetTypeLimitItemsHandler);
 web.wrapRoutePost(app, '/simsearch/phenotype', '/simsearch/phenotype', [], simsearchPhenotypeByTargetTypeLimitItemsHandler);
 
-function annotateByTextHandler(request, fmt) {
+
+function annotateTextHandler(request) {
     var q = env.isRingoJS() ? request.params.q : request.query.q;
     var longestOnly = env.isRingoJS() ? request.params.longestOnly : request.query.longestOnly;
 
@@ -2651,7 +2663,7 @@ function annotateByTextHandler(request, fmt) {
     else {
         info.results = engine.annotateText(q, {longestOnly : longestOnly});
         info.results.forEach(function(r) {
-            engine.log("RES:"+JSON.stringify(r));
+            // engine.log("RES:"+JSON.stringify(r));
             if (r.token.categories.indexOf('Phenotype') > -1) {
                 pheno_ids.push(r.token.id);
             }
@@ -2731,10 +2743,10 @@ function annotateByTextHandler(request, fmt) {
     return web.wrapHTML(output);
 }
 
-web.wrapRouteGet(app, '/annotate/text.:fmt?', '/annotate/text', ['fmt'], annotateByTextHandler);
+web.wrapRouteGet(app, '/annotate/text', '/annotate/text', [], annotateTextHandler);
 
 
-app.get('/annotate_minimal/text.:fmt?', function(request, fmt) {
+function annotateMinimalTextHandler(request, fmt) {
     var q = request.params.q;
 
     var info =
@@ -2758,10 +2770,15 @@ app.get('/annotate_minimal/text.:fmt?', function(request, fmt) {
     addCoreRenderers(info, 'annotate');
     info.hasResults = (info.results.length > 0);
     var output = pup_tent.render('annotate_minimal.mustache',info,'monarch_base.mustache');
-    return response.html(output);
-});
+    return web.wrapHTML(output);
+}
 
-app.get('/sufficiency/basic.:fmt?', function(request, datatype, fmt) {
+// Order matters here in the declaration of these routes.
+web.wrapRouteGet(app, '/annotate_minimal/text/:id.:fmt?', '/annotate_minimal/text/{id}.{fmt}', ['id', 'fmt'], annotateMinimalTextHandler);
+web.wrapRouteGet(app, '/annotate_minimal/text/:id', '/annotate_minimal/text/{id}', ['id'], annotateMinimalTextHandler);
+
+
+function sufficiencyBasicHandler(request, datatype, fmt) {
     var target = null;
     var info = {datatype: datatype, results:[]};
     var limit = 100;
@@ -2773,9 +2790,14 @@ app.get('/sufficiency/basic.:fmt?', function(request, datatype, fmt) {
     info.input_items = input_items.join("\n");
 
     return response.json(info.results);
-});
+}
 
-app.get('/scigraph/dynamic*.:fmt?', function(request) {
+// Order matters here in the declaration of these routes.
+web.wrapRouteGet(app, '/sufficiency/basic/:id.:fmt?', '/sufficiency/basic/{id}.{fmt}', ['id', 'fmt'], sufficiencyBasicHandler);
+web.wrapRouteGet(app, '/sufficiency/basic/:id', '/sufficiency/basic/{id}', ['id'], sufficiencyBasicHandler);
+
+
+function scigraphDynamicHandler(request, id, fmt) {
     //this presently is a scigraph pass-through wrapper, and only deals with json!
     //for example: /dynamic/homologs.json?gene_id=6469&homolog_id=RO_HOM0000000
     var path = request.pathInfo;
@@ -2786,12 +2808,16 @@ app.get('/scigraph/dynamic*.:fmt?', function(request) {
 
     var scigraph_results = engine.querySciGraphDynamicServices(path,params);
 
-    return response.json(scigraph_results)
+    return response.json(scigraph_results);
+}
 
+// Order matters here in the declaration of these routes.
+web.wrapRouteGet(app, '/scigraph/dynamic*/:id.:fmt?', '/scigraph/dynamic*/{id}.{fmt}', ['id', 'fmt'], scigraphDynamicHandler);
+web.wrapRouteGet(app, '/scigraph/dynamic*/:id', '/scigraph/dynamic*/{id}', ['id'], scigraphDynamicHandler);
 
-});
 
 // proxy kegg api
+if (env.isRingoJS()) { /* TODO: CONVERT_TO_DUAL_MODE */
 app.get('/kegg/:operation/:arg1/:arg2?/:arg3?', function(request, operation, arg1, arg2, arg3) {
     var url = 'http://rest.kegg.jp/' + operation + '/' + arg1;
     if (arg2) url = url + '/' + arg2;
@@ -2812,55 +2838,60 @@ app.get('/kegg/:operation/:arg1/:arg2?/:arg3?', function(request, operation, arg
             status: status
         };
     }
-
-
 });
+}
 
-app.get('/admin/introspect.:fmt?', function(request, fmt) {
+
+function adminIntrospectHandler(request, fmt) {
 
     var info = engine.introspect();
 
     // you can have any format you like, so long as it's json
-    return response.json(info);
-});
+    return web.wrapJSON(info);
+}
 
-app.get('/admin/cache/info', function(request, fmt) {
+// Order matters here in the declaration of these routes.
+web.wrapRouteGet(app, '/admin/introspect.:fmt?', '/admin/introspect.{fmt}', ['fmt'], adminIntrospectHandler);
+web.wrapRouteGet(app, '/admin/introspect', '/admin/introspect', [], adminIntrospectHandler);
 
-    var info = {
-        sizeInfo : engine.cache.sizeInfo(),
-        cacheDirs : engine.cache.cacheDirs(),
-        contents : engine.cache.contents().length
-    };
 
-    // you can have any format you like, so long as it's json
-    return response.json(info);
-});
+web.wrapRouteGet(app, '/admin/cache/info', '/admin/cache/info', [],
+    function(request, fmt) {
+
+        var info = {
+            sizeInfo : engine.cache.sizeInfo(),
+            cacheDirs : engine.cache.cacheDirs(),
+            contents : engine.cache.contents().length
+        };
+
+        // you can have any format you like, so long as it's json
+        return web.wrapJSON(info);
+    });
 
 
 // in theory anyone could access this and clear our cache slowing things down....
 // we should make this authorized, not really a concern right now though
-app.get('/admin/clear-cache', function(request, reply) {
-    engine.cache.clear(request.params.match);
-    if (env.isRingoJS()) {
-        return response.html("Cleared!");
-    }
-    else {
-        reply("Cleared!");
-    }
-});
+web.wrapRouteGet(app, '/admin/clear-cache', '/admin/clear-cache', [],
+    function(request) {
+        engine.cache.clear(web.getParam(request, 'match'));
+        return web.wrapHTML("Cleared!");
+    });
+
 
 // A routing page different non-production demonstrations and tests.
-app.get('/labs',
-    function(request, page){
+web.wrapRouteGet(app, '/labs', '/labs', [],
+    function(request) {
         var info = {};
         addCoreRenderers(info);
         info.pup_tent_css_libraries.push("/tour.css");
         info.title = 'Monarch Labs'
         var output = pup_tent.render('labs.mustache', info,
                      'monarch_base.mustache');
-        return response.html(output);
-});
+        return web.wrapHTML(output);
+    });
 
+
+if (false) { /* Disabling all /legacy/xxx and /labs/xxx endpoints that aren't dual-mode */
 app.get('/labs/golr/:id.:fmt?',
         function(request, id, fmt){
     
@@ -2894,7 +2925,10 @@ app.get('/labs/golr/:id.:fmt?',
         return errorResponse(err);
     }
 });
+}
 
+
+if (false) { /* Disabling all /legacy/xxx and /labs/xxx endpoints that aren't dual-mode */
 //A routing page different non-production demonstrations and tests.
 app.get('/labs/dovegraph.:fmt?',function(request,fmt){
     
@@ -2905,8 +2939,8 @@ app.get('/labs/dovegraph.:fmt?',function(request,fmt){
         info.pup_tent_js_variables.push({name:'global_scigraph_url',
             value: engine.config.scigraph_url});
         
-        var phenoDist = JSON.parse(env.fs_readFileSync('./widgets/dove/stats/key-phenotype-annotation-distro.json'));       
-        var hpStub = JSON.parse(env.fs_readFileSync('./widgets/dove/stats/hp-ontology-4.json'));
+        var phenoDist = env.readJSON('./widgets/dove/stats/key-phenotype-annotation-distro.json');
+        var hpStub = env.readJSON('./widgets/dove/stats/hp-ontology-4.json');
 
         if (fmt != null) {
             return formattedResults(info,fmt,request);
@@ -2939,7 +2973,10 @@ app.get('/labs/dovegraph.:fmt?',function(request,fmt){
         var output = pup_tent.render('dovegraph.mustache',info,'monarch_base.mustache');
         return response.html(output);
 });
+}
 
+
+if (false) { /* Disabling all /legacy/xxx and /labs/xxx endpoints that aren't dual-mode */
 // A routing page different non-production demonstrations and tests.
 app.get('/labs/cy-path-demo',
     function(request, page){
@@ -2960,7 +2997,10 @@ app.get('/labs/cy-path-demo',
         var output = pup_tent.render('cy-path-demo.mustache',info,'monarch_base.mustache');
         return response.html(output);
 });
+}
 
+
+if (false) { /* Disabling all /legacy/xxx and /labs/xxx endpoints that aren't dual-mode */
 // A routing page different non-production demonstrations and tests.
 app.get('/labs/cy-explore-demo',
     function(request, page){
@@ -2981,7 +3021,10 @@ app.get('/labs/cy-explore-demo',
         var output = pup_tent.render('cy-explore-demo.mustache',info,'monarch_base.mustache');
         return response.html(output);
     });
+}
 
+
+if (false) { /* Disabling all /legacy/xxx and /labs/xxx endpoints that aren't dual-mode */
 //Page for testing out chromosome visualization
 app.get('/labs/chromosome-vis-demo',
     function(request, page){
@@ -3018,6 +3061,8 @@ app.get('/labs/chromosome-vis-demo',
         var output = pup_tent_test.render('chromosome-vis-demo.mustache',info);
         return response.html(output);
  });
+}
+
 
 // Playing around with remote resource/feed reading.
 // TODO: If it gets /any/ more complicated, reform into an object.
@@ -3143,8 +3188,6 @@ function _get_blog_data(label) {
 }
 
 
-
-
 function _sortByLabel(array) {
     if (array == null) return;
     array.sort(function(a, b){
@@ -3160,10 +3203,16 @@ function _sortByLabel(array) {
             return 0 //default return value (no sorting)
               })
   return array;
-
 }
 
 
+// Method: /
+//
+// Arguments:
+//  - none
+//
+// Returns:
+//  Top level page
 function homeHandler(request) {
   // Rendering.
   var info = {};
@@ -3198,6 +3247,7 @@ function homeHandler(request) {
 web.wrapRouteGet(app, '/', '/', [], homeHandler);
 
 
+if (false) { /* Disabling all /legacy/xxx and /labs/xxx endpoints that aren't dual-mode */
 app.get('/labs/scratch-homepage', function(request, page){
 
     // Rendering.
@@ -3216,7 +3266,7 @@ app.get('/labs/scratch-homepage', function(request, page){
     info.pup_tent_js_libraries.push("/HomePage.js");
     
     //graph
-    var phenoDist = JSON.parse(env.fs_readFileSync('./widgets/dove/stats/key-phenotype-annotation-distro.json'));
+    var phenoDist = env.readJSON('./widgets/dove/stats/key-phenotype-annotation-distro.json');
     info.pup_tent_js_libraries.push("/dovechart.js");
     info.pup_tent_js_libraries.push("/d3.3.5.5.min.js");
     info.pup_tent_css_libraries.push("/dovegraph.css");
@@ -3242,7 +3292,10 @@ app.get('/labs/scratch-homepage', function(request, page){
     var res =  response.html(output);
     return res;
 });
+}
 
+
+if (false) { /* Disabling all /legacy/xxx and /labs/xxx endpoints that aren't dual-mode */
 app.get('/labs/blog-test', function(request, page){
 
     // Rendering.
@@ -3268,6 +3321,8 @@ app.get('/labs/blog-test', function(request, page){
     var res =  response.html(output);
     return res;
 });
+}
+
 
 /*
  * GOLR REFACTOR
@@ -3327,6 +3382,7 @@ function addGolrTable(info, query_field, id, div, filter, personality, anchor) {
 }
 
 
+if (false) { /* Disabling all /legacy/xxx and /labs/xxx endpoints that aren't dual-mode */
 app.get('/labs/widget-scratch',
     function(request, page){
 
@@ -3351,6 +3407,7 @@ app.get('/labs/widget-scratch',
         var res =  response.html(output);
         return res;
  });
+}
 
 
 function phenotypeByIdHandler(request, id, fmt){
@@ -3471,22 +3528,27 @@ web.wrapRouteGet(app, '/phenotype/:id', '/phenotype/{id}', ['id'], phenotypeById
 //PHENOTYPE - Sub-pages
 //Example: /phenotype/MP_0000854/phenotype_associations.json
 //Currently only works for json or rdf output
-app.get('/phenotype/:id/:section.:fmt?', function(request, id, section, fmt) {
+function phenotypeByIdSectionHandler(request, id, section, fmt) {
 
- var info = engine.fetchClassInfo(id, {level:1});
+    var info = engine.fetchClassInfo(id, {level:1});
 
- var sectionInfo =
-     { id: "obo:"+id }; // <-- TODO - unify ID/URI strategy
- sectionInfo[section] = info[section];
- engine.addJsonLdContext(sectionInfo);
+    var sectionInfo =
+        { id: "obo:"+id }; // <-- TODO - unify ID/URI strategy
+    sectionInfo[section] = info[section];
+    engine.addJsonLdContext(sectionInfo);
 
- if (fmt != null) {
-     return formattedResults(sectionInfo, fmt,request);
- }
- else {
-     return response.error("plain HTML does not work for page sections. Please append .json or .rdf to URL");
- }
-});
+    if (fmt != null) {
+        return formattedResults(sectionInfo, fmt,request);
+    }
+    else {
+        return response.error("plain HTML does not work for page sections. Please append .json or .rdf to URL");
+    }
+}
+
+// Order matters here in the declaration of these routes.
+web.wrapRouteGet(app, '/phenotype/:id/:section.:fmt', '/phenotype/{id}/{section}.{fmt}', ['id', 'section', 'fmt'], phenotypeByIdSectionHandler);
+web.wrapRouteGet(app, '/phenotype/:id/:section', '/phenotype/{id}/{section}', ['id', 'section'], phenotypeByIdSectionHandler);
+
 
 
 function diseaseByIdHandler(request, id, fmt) {
@@ -3654,19 +3716,19 @@ web.wrapRouteGet(app, '/disease/:id', '/disease/{id}', ['id'], diseaseByIdHandle
 //Example: /disease/DOID_12798/phenotype_associations.json
 //Currently only works for json or rdf output
 
-    function diseaseByIdSectionHandler(request, id, section, fmt){
-        var info = engine.fetchCoreDiseaseInfo(id);
-        var sectionInfo =
-             { id: "obo:"+id }; // <-- TODO - unify ID/URI strategy
-        sectionInfo[section] = info[section];
-        engine.addJsonLdContext(sectionInfo);
+function diseaseByIdSectionHandler(request, id, section, fmt){
+    var info = engine.fetchCoreDiseaseInfo(id);
+    var sectionInfo =
+         { id: "obo:"+id }; // <-- TODO - unify ID/URI strategy
+    sectionInfo[section] = info[section];
+    engine.addJsonLdContext(sectionInfo);
 
-        if (fmt != null) {
-            return formattedResults(sectionInfo, fmt, request);
-        } else {
-            return errorResponse("plain HTML does not work for page sections. Please append .json or .rdf to URL");
-        }
+    if (fmt != null) {
+        return formattedResults(sectionInfo, fmt, request);
+    } else {
+        return errorResponse("plain HTML does not work for page sections. Please append .json or .rdf to URL");
     }
+}
 
 // Order matters here in the declaration of these routes.
 web.wrapRouteGet(app, '/disease/:id/:section.:fmt', '/disease/{id}/{section}.{fmt}', ['id', 'section', 'fmt'], diseaseByIdSectionHandler);
@@ -3688,8 +3750,8 @@ function fetchFeatureSection(request, id, section, fmt) {
     }
 }
 
-web.wrapRouteGet(app, '/gene/:id.:fmt?', '/gene/{id}', ['id'],
-    function(request, id, fmt) {
+
+function geneByIdHandler(request, id, fmt) {
     try {
         
         //Curify ID if needed
@@ -3837,7 +3899,11 @@ web.wrapRouteGet(app, '/gene/:id.:fmt?', '/gene/{id}', ['id'],
     }
     
 }
-);
+
+// Order matters here in the declaration of these routes.
+web.wrapRouteGet(app, '/gene/:id.:fmt?', '/gene/{id}.{fmt}', ['id', 'fmt'], geneByIdHandler);
+web.wrapRouteGet(app, '/gene/:id', '/gene/{id}', ['id'], geneByIdHandler);
+
 
 var redirectGenePage = function(id, equivalentNodes) {
    var prefix = id.replace(/(\w+):([\w\d]+)/, "$1");
@@ -3873,6 +3939,7 @@ var redirectGenePage = function(id, equivalentNodes) {
 
 };
 
+
 var redirectDiseasePage = function(id, equivalentNodes) {
     var prefix = id.replace(/(\w+):([\w\d]+)/, "$1");
     var nodeMap = {};
@@ -3900,7 +3967,7 @@ var redirectDiseasePage = function(id, equivalentNodes) {
 
 
 //Note there is much copied from the above function, should refactor to not repeat code, epic DRY violation
-var fetchVariantPage = function(request, id, fmt) {
+function variantByIdHandler(request, id, fmt) {
     try {
 
         // Rendering.
@@ -4027,7 +4094,7 @@ var fetchVariantPage = function(request, id, fmt) {
         
         var output = pup_tent.render('variant.mustache', info,
                  'monarch_base.mustache');
-        return response.html(output);
+        return web.wrapHTML(output);
         
     } catch(err) {
         return errorResponse(err);
@@ -4035,8 +4102,11 @@ var fetchVariantPage = function(request, id, fmt) {
     
 }
 
+// Order matters here in the declaration of these routes.
+web.wrapRouteGet(app, '/variant/:id.:fmt?', '/variant/{id}.{fmt}', ['id', 'fmt'], variantByIdHandler);
+web.wrapRouteGet(app, '/variant/:id', '/variant/{id}', ['id'], variantByIdHandler);
 
-app.get('/variant/:id', fetchVariantPage);
+
 
 //Sequence Feature - Sub-pages
 //Example: /gene/NCIBGene:12166/phenotype_associations.json
@@ -4047,6 +4117,8 @@ web.wrapRouteGet(app, '/variant/:id/:section.:fmt?', '/variant/{id}/{section}.{f
 web.wrapRouteGet(app, '/genotype/:id/:section.:fmt?', '/genotype/{id}/{section}.{fmt?}', ['id', 'section', 'fmt'], fetchFeatureSection);
 web.wrapRouteGet(app, '/model/:id/:section.:fmt?', '/model/{id}/{section}.{fmt?}', ['id', 'section', 'fmt'], fetchFeatureSection);
 
+
+if (false) { /* Disabling all /legacy/xxx and /labs/xxx endpoints that aren't dual-mode */
 app.get('/labs/case/:id/phenotype_list.:fmt?', function(request, id, fmt){
     var info = {};
     info = engine.fetchPatientInfo(id);
@@ -4057,7 +4129,9 @@ app.get('/labs/case/:id/phenotype_list.:fmt?', function(request, id, fmt){
         return response.error("plain HTML does not work for page sections. Please append .json or .rdf to URL");
     }
 });
+}
 
+if (false) { /* Disabling all /legacy/xxx and /labs/xxx endpoints that aren't dual-mode */
 app.get('/labs/case/:id', function(request, id, fmt){
     var info = {};
     info = engine.fetchPatientInfo(id);
@@ -4099,10 +4173,11 @@ app.get('/labs/case/:id', function(request, id, fmt){
         'monarch_base.mustache');
     return response.html(output);
 });
+}
 
 
-app.get('/association/:id.:fmt?',
-        function(request, id, fmt){
+if (false) {    // The /association/ endpoint is not used. Delete it
+function associationById(request, id, fmt){
     
         try {
             
@@ -4164,12 +4239,18 @@ app.get('/association/:id.:fmt?',
             
             var output = pup_tent.render('associations.mustache', info,
                                          'monarch_base.mustache');
-            return response.html(output);
+            return web.wrapHTML(output);
             
         } catch(err) {
             return errorResponse(err);
         }
- });
+}
+
+// Order matters here in the declaration of these routes.
+web.wrapRouteGet(app, '/association/:id.:fmt?', '/association/{id}.{fmt}', ['id', 'fmt'], associationByIdHandler);
+web.wrapRouteGet(app, '/association/:id', '/association/{id}', ['id'], associationByIdHandler);
+}
+
 
 function addPhenotypeAnchor(info) {
     var phenotype_anchor = {id: info.id,
@@ -4293,6 +4374,7 @@ function addGenotypeTableWithFilter() {
  */
 
 
+if (false) { /* Disabling all /legacy/xxx and /labs/xxx endpoints that aren't dual-mode */
 app.get('/labs/people-scratch', function(request, page){
 
     // Rendering.
@@ -4314,12 +4396,15 @@ app.get('/labs/people-scratch', function(request, page){
     var res =  response.html(output);
     return res;
 });
+}
+
 
 ///
 /// Routes for a demonstration of JBrowse in Monarch.
 ///
 
 // Deliver content from directory mapped to path.
+if (false) { /* Disabling all /legacy/xxx and /labs/xxx endpoints that aren't dual-mode */
 app.get('/labs/jbrowse/*', function(request){
 
     // Extract path from request.
@@ -4347,6 +4432,10 @@ app.get('/labs/jbrowse/*', function(request){
         return res ;
     }
 });
+}
+
+
+if (false) { /* Disabling all /legacy/xxx and /labs/xxx endpoints that aren't dual-mode */
 // Deliver content from directory mapped to path.
 app.get('/labs/jbrowse-demo', function(request){
 
@@ -4361,11 +4450,12 @@ app.get('/labs/jbrowse-demo', function(request){
     var res =  response.html(output);
     return res;
 });
+}
+
 
 ///
 /// Error handling.
 ///
-
 
 // Add an error for all of the rest.
 function notFoundHandler(request) {
@@ -4373,14 +4463,8 @@ function notFoundHandler(request) {
 }
 web.wrapRouteGet(app, '/*', '/{other*}', [], notFoundHandler);
 
-if (env.isRingoJS()) {
-    // INITIALIZATION
-    // Can set port from command line. E.g. --port 8080
-    if (require.main == module) {
-       require('ringo/httpserver').main(module.id);
-    }
-}
 
+if (false) { /* Disabling all /legacy/xxx and /labs/xxx endpoints that aren't dual-mode */
 //TODO Delete
 app.get('/labs/gene/:id.:fmt?', function(request, id, fmt) {
 
@@ -4480,6 +4564,7 @@ app.get('/labs/gene/:id.:fmt?', function(request, id, fmt) {
     var output = pup_tent.render('gene-jbrowse.mustache',info,'monarch_base.mustache');
     return response.html(output);
 });
+}
 
 
 function analyzeByDatatypePostHandler(request, datatype, fmt) {
@@ -4730,6 +4815,7 @@ web.wrapRouteGet(app, '/analyze/:datatype/', '/analyze/{datatype}/', ['datatype'
 web.wrapRouteGet(app, '/analyze/:datatype', '/analyze/{datatype}', ['datatype'], analyzeByDatatypeGetHandler);
 
 
+if (false) { /* Disabling all /legacy/xxx and /labs/xxx endpoints that aren't dual-mode */
  app.get('/labs/classenrichment', function(request) {
      var info = {};
      addCoreRenderers(info);
@@ -4739,6 +4825,7 @@ web.wrapRouteGet(app, '/analyze/:datatype', '/analyze/{datatype}', ['datatype'],
      var output = pup_tent.render('class-enrichment-demo.mustache',info,'monarch_base.mustache');
      return response.html(output);
  });
+}
 
  /**
   * Mostly copied from parseFileUpload from ringo/http
@@ -4964,6 +5051,7 @@ web.wrapRouteGet(app, '/resolve/:id.:fmt?', '/resolve/{id}.{fmt}', ['id', 'fmt']
 web.wrapRouteGet(app, '/resolve/:id', '/resolve/{id}', ['id'], resolveByIdHandler);
 
 
+if (false) { /* Disabling all /legacy/xxx and /labs/xxx endpoints that aren't dual-mode */
  //TODO Delete this, for testing of the new ontology browser
  app.get('/labs/phenotype/:id.:fmt?',
          function(request, id, fmt){
@@ -5071,4 +5159,50 @@ web.wrapRouteGet(app, '/resolve/:id', '/resolve/{id}', ['id'], resolveByIdHandle
              return response.html(output);
              return res;
   });
+}
 
+app.configServer = function(defaultConfig, golrConfig) {
+    this.defaultConfig = defaultConfig;
+    this.golrConfig = golrConfig;
+
+    if (env.isRingoJS()) {
+        module.singleton("monarchConfig",
+            function() {
+                return {
+                        defaultConfig: defaultConfig,
+                        golrConfig: golrConfig
+                    };
+                });
+    }
+};
+
+app.startServer = function() {
+    if (env.isRingoJS()) {
+        var config = module.singleton("monarchConfig");
+        this.defaultConfig = config.defaultConfig;
+        this.golrConfig = config.golrConfig;
+    }
+    engine = buildEngine(this.defaultConfig, this.golrConfig);
+    if (env.isRingoJS()) {
+        // INITIALIZATION
+        // Can set port from command line. E.g. --port 8080
+        // console.log('require.main.id:', Object.keys(require.main), require.main.id, ' module.id:', Object.keys(module), module.id);
+        if (!global.ringoServerInitialized) {
+            global.ringoServerInitialized = true;
+            var server = require('ringo/httpserver').main('web/stickloader');
+            var connectors = server.getJetty().getConnectors();
+            var c1 = connectors[0];
+            console.log('RingoJS Server running at:', c1.getHost(), ':', c1.getPort());
+        }
+    }
+    else {
+        var that = this;
+        this.app.start(function () {
+            console.log('HapiJS Server running at:', that.app.info.uri);
+        });
+    }
+};
+
+exports.app = app;
+exports.configServer = app.configServer;
+exports.startServer = app.startServer;

--- a/lib/monarch/web/webapp_launcher.js
+++ b/lib/monarch/web/webapp_launcher.js
@@ -1,12 +1,10 @@
-var env = require('../serverenv.js');
+var env = require('serverenv.js');
 
 if (env.isRingoJS()) {
-	load('lib/monarch/api.js');
-	load('lib/monarch/web/widgets.js');
 	load('lib/monarch/web/webapp.js');
 }
 else {
-	eval(env.fs_readFileSync('lib/monarch/api.js')+'');
-	eval(env.fs_readFileSync('lib/monarch/web/widgets.js')+'');
 	eval(env.fs_readFileSync('lib/monarch/web/webapp.js')+'');
 }
+
+console.log("end of webapp_launcher.js");

--- a/lib/monarch/web/webapp_launcher_dev.js
+++ b/lib/monarch/web/webapp_launcher_dev.js
@@ -1,10 +1,10 @@
-var fs = require('fs');
-var bbop = require('bbop');
-if (typeof bbop == 'undefined') { var bbop = {};}
-if (typeof bbop.monarch == 'undefined') { bbop.monarch = {};}
-//see: https://docs.google.com/document/d/1ZxGuuvyvMmHVWQ7rIleIRkmbiDTNNP27eAHhxyFWHok/edit#
+console.log("This is a RingoJS development server1");
 
-bbop.monarch.defaultConfig = JSON.parse(fs.read("conf/server_config_dev.json"));
-bbop.monarch.golrConfig = JSON.parse(fs.read("conf/golr-conf.json"));
-load('lib/monarch/web/webapp_launcher.js');
-console.log("This is a development server");
+var env = require('serverenv.js');
+var app = require('web/webapp.js');
+
+var defaultConfig = env.readJSON("conf/server_config_dev.json");
+var golrConfig = env.readJSON("conf/golr-conf.json");
+
+app.configServer(defaultConfig, golrConfig);
+app.startServer();

--- a/lib/monarch/web/webapp_launcher_node.js
+++ b/lib/monarch/web/webapp_launcher_node.js
@@ -1,12 +1,10 @@
-var env = require('../serverenv.js');
+console.log("This is a NodeJS development server1");
 
-var bbop = require('bbop');
-if (typeof bbop == 'undefined') { var bbop = {};}
-if (typeof bbop.monarch == 'undefined') { bbop.monarch = {};}
-//see: https://docs.google.com/document/d/1ZxGuuvyvMmHVWQ7rIleIRkmbiDTNNP27eAHhxyFWHok/edit#
+var env = require('serverenv.js');
+var webapp = require('web/webapp.js');
 
-console.log("This is a development server1");
+var defaultConfig = env.readJSON("conf/server_config_dev.json");
+var golrConfig = env.readJSON("conf/golr-conf.json");
 
-bbop.monarch.defaultConfig = JSON.parse(env.fs_readFileSync("conf/server_config_dev.json"));
-bbop.monarch.golrConfig = JSON.parse(env.fs_readFileSync("conf/golr-conf.json"));
-eval(env.fs_readFileSync('lib/monarch/web/webapp_launcher.js')+'');
+webapp.configServer(defaultConfig, golrConfig);
+webapp.startServer();

--- a/lib/monarch/web/widgets.js
+++ b/lib/monarch/web/widgets.js
@@ -1,4 +1,5 @@
-var convChars =  require("./utils").convChars;
+var convChars =  require("web/utils.js").convChars;
+var env = require('serverenv.js');
 
 // GENERIC
 function genTable(spec, rows) {
@@ -178,6 +179,11 @@ function genExternalHref(type,obj,fmt) {
     } else {
         return label;
     }
+}
+
+function getConfig(t) {
+    var s = env.readJSON('conf/'+t+'.json');
+    return s;
 }
 
 function getXrefObjByPrefix(prefix) {
@@ -1530,3 +1536,51 @@ function sourceImage(source) {
 function searchBar() {
     // TODO
 }
+
+exports.genTable = genTable;
+exports.tableSortDataType = tableSortDataType;
+exports.genObjectHref = genObjectHref;
+exports.genObjectHrefs = genObjectHrefs;
+exports.genSourceHref = genSourceHref;
+exports.genExternalHref = genExternalHref;
+exports.getConfig = getConfig;
+exports.getXrefObjByPrefix = getXrefObjByPrefix;
+exports.makeExternalURL = makeExternalURL;
+exports.genURL = genURL;
+exports.genTableOfClasses = genTableOfClasses;
+exports.genTableOfSearchResults = genTableOfSearchResults;
+exports.genTableOfSearchDataResults = genTableOfSearchDataResults;
+exports.genTableOfDataSources = genTableOfDataSources;
+exports.genTableOfAnnotateTextResults = genTableOfAnnotateTextResults;
+exports.genTableOfAnalysisSearchResults = genTableOfAnalysisSearchResults;
+exports.mapIdentifierToTaxon = mapIdentifierToTaxon;
+exports.makeReferencesFromAssociations = makeReferencesFromAssociations;
+exports.genTableOfDiseasePhenotypeAssociations = genTableOfDiseasePhenotypeAssociations;
+exports.genTableOfGenePhenotypeAssociations = genTableOfGenePhenotypeAssociations;
+exports.genTableOfGenePhenotypeAssociations = genTableOfGenePhenotypeAssociations;
+exports.genTableOfGeneDiseaseAssociations = genTableOfGeneDiseaseAssociations;
+exports.genTableOfGeneXRefs = genTableOfGeneXRefs;
+exports.genTableOfGeneAlleleAssociations = genTableOfGeneAlleleAssociations;
+exports.genTableOfGeneOrthologAssociations = genTableOfGeneOrthologAssociations;
+exports.genTableOfGeneInteractionAssociations = genTableOfGeneInteractionAssociations;
+exports.genTableOfGeneGenotypeAssociations = genTableOfGeneGenotypeAssociations;
+exports.genTableOfGenoVariantAssociations = genTableOfGenoVariantAssociations;
+exports.genListOfExternalIdentifierLinks = genListOfExternalIdentifierLinks;
+exports.genTableOfDiseaseGeneAssociations = genTableOfDiseaseGeneAssociations;
+exports.genTableOfDiseaseAlleleAssociations = genTableOfDiseaseAlleleAssociations;
+exports.genTableOfDiseaseAlleleAssociations = genTableOfDiseaseAlleleAssociations;
+exports.genTableOfGenotypePhenotypeAssociations = genTableOfGenotypePhenotypeAssociations;
+exports.genTableOfDiseaseModelAssociations = genTableOfDiseaseModelAssociations;
+exports.genTableOfGeneExpressionAssocations = genTableOfGeneExpressionAssocations;
+exports.genTableOfSimilarModels = genTableOfSimilarModels;
+exports.genTableOfSimilarDiseases = genTableOfSimilarDiseases;
+exports.genTableOfDiseasePathwayAssociations = genTableOfDiseasePathwayAssociations;
+exports.genTableOfSimilarPapers = genTableOfSimilarPapers;
+exports.genTableOfLiteratureGenes = genTableOfLiteratureGenes;
+exports.genTableOfLiterature = genTableOfLiterature;
+exports.genOverviewOfGenotype = genOverviewOfGenotype;
+exports.genKeggeratorAction = genKeggeratorAction;
+exports.genKEGGShowPathwayLink = genKEGGShowPathwayLink;
+exports.genTableOfGenePathwayAssociations = genTableOfGenePathwayAssociations;
+exports.sourceImage = sourceImage;
+exports.searchBar = searchBar;

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "binary": "^0.3.0",
     "core-util-is": "^1.0.1",
     "events": "^1.0.2",
-    "hapi": "^8.8.0",
+    "hapi": "^9.3.0",
+    "inert": "^3.0.1",
     "isarray": "0.0.1",
     "lodash": "^3.10.1",
     "lodash._isiterateecall": "^3.0.9",
@@ -29,14 +30,15 @@
     "phenogrid": "git+https://github.com/monarch-initiative/phenogrid.git#release_2015-08-06",
     "request": "^2.60.0",
     "sax": "^1.1.1",
+    "timers": "^0.1.1",
     "underscore": "1.8.3",
     "wait.for": "^0.6.6",
     "xml2js": "^0.4.10",
     "xmlbuilder": "^2.6.4"
   },
   "devDependencies": {
-    "chai": "^2.3.0",
-    "del": "^1.1.1",
+    "chai": "^3.2.0",
+    "del": "^2.0.1",
     "glob": "^5.0.14",
     "gulp": "^3.9.0",
     "gulp-bump": "^0.3.0",
@@ -46,7 +48,7 @@
     "gulp-rename": "^1.2.2",
     "gulp-uglify": "^1.2.0",
     "js-yaml": "^3.3.1",
-    "map-stream": "^0.0.5"
+    "map-stream": "^0.0.6"
   },
   "bundleDependencies": [],
   "private": false,

--- a/server.js
+++ b/server.js
@@ -1,3 +1,0 @@
-load('lib/monarch/api.js');
-load('lib/monarch/web/widgets.js');
-load('lib/monarch/web/webapp.js');

--- a/tests/behave/maui_utilities.feature
+++ b/tests/behave/maui_utilities.feature
@@ -1,0 +1,83 @@
+Feature: NodeJS and RingoJS pass all tests.
+ Monarch-app JSON blobs behave as expected for various data.
+
+@ui
+ Scenario: The "/search" endpoint returns the correct JSON
+    Given I go to page "/search/twist"
+     then the title should be "Search Results: twist"
+     then the document should contain "Search Results: twist"
+
+@ui
+ Scenario: The "/sources" endpoint returns the correct HTML
+    Given I go to page "/sources"
+     then the title should be "Data Sources"
+     then the document should contain "Data Sources"
+
+@ui
+ Scenario: The "/sources.json" endpoint returns the correct JSON
+    Given I go to page "/sources.json"
+     then the document should contain '"resource_description":"BioGRID is'
+
+@ui
+ Scenario: The "/admin/introspect" endpoint returns the correct JSON
+    Given I go to page "/admin/introspect"
+     then the document should contain '"config":'
+
+@ui
+ Scenario: The "/admin/introspect.json" endpoint returns the correct JSON
+    Given I go to page "/admin/introspect.json"
+     then the document should contain '"config":'
+
+@ui
+ Scenario: The "/variant/ClinVarVariant:30599" endpoint returns the correct page
+    Given I go to page "/variant/ClinVarVariant:30599"
+     then the document should contain "Variant: NM_017882.2(CLN6):c.200T>C (p.Leu67Pro)"
+     then the title should be "Monarch Variant: NM_017882.2(CLN6):c.200T>C (p.Leu67Pro) (ClinVarVariant:30599)"
+
+@ui
+ Scenario: The "/status" endpoint returns the correct JSON
+    Given I go to page "/status"
+     then the document should contain '"name":"Monarch Application"'
+
+@ui
+ Scenario: The "/robots.txt" endpoint returns the correct JSON
+    Given I go to page "/robots.txt"
+     then the document should contain "User-agent: *"
+
+@ui
+ Scenario Outline: the documentation pages exist
+   Given I go to page "<page>"
+    then the title should be "<title>"
+    and the document should contain "<content>"
+   Examples: doc pages
+    | page                              | title             | content                       |
+    | /docs/index.html                  | monarch.api       | fetchDiseaseInfo              |
+    | /docs/files/web/webapp-js.html    | webapp            | Monarch REST URLs for retrieving web pages, JSON and HTML|
+    | /docs/files/web/webapp-js.html#webapp.simsearch    | webapp            | Performs OwlSim search|
+
+@ui
+ Scenario: The "/compare/" endpoint returns the correct JSON
+    Given I go to page "/compare/OMIM:270400/NCBIGene:5156,OMIM:249000,OMIM:194050.json"
+     then the document should contain "Smith-Lemli-Opitz syndrome"
+
+
+@ui
+Scenario: The "/query/orthologs/" endpoint returns the correct JSON
+   Given I go to page "/query/orthologs/NCBIGene:5156"
+   then the document should contain '"input":["NCBIGene:5156"]'
+
+
+
+@ui
+ Scenario: The "/annotate/text" endpoint returns the correct query page
+    Given I go to page "/annotate/text"
+     then the document should contain "Text Annotator"
+     then the title should be "Annotation"
+
+
+@ui
+ Scenario: The "/annotate/text" endpoint returns the correct results page
+    Given I go to page "/annotate/text?q=In+the+LEOPARD+syndrome+%28151100%29+vestibular+function+is+normal."
+     then the document should contain "Marked Up Text"
+     then the title should be "Annotation"
+

--- a/tests/behave/steps/selenium-basic.py
+++ b/tests/behave/steps/selenium-basic.py
@@ -65,6 +65,14 @@ def step_impl(context, text):
     # print(webelt.get_attribute('innerHTML'))
     # assert webelt.get_attribute('innerHTML').rfind(text) != -1
 
+## The document body should contain a certain piece of text.
+@then("the document should contain '{text}'")
+def step_impl(context, text):
+    print(context.browser.title)
+    webelt = context.browser.find_element_by_tag_name('html')
+    print(webelt.text)
+    assert webelt.text.rfind(text) != -1
+
 ## The document body should not contain a hyperlink with text.
 @then('the document should not contain link with "{text}"')
 def step_impl(context, text):


### PR DESCRIPTION
Do not use webapp_launcher.js, use webapp_launcher_node.js or webapp_launcher_dev.js. I haven't converted webapp_launcher.js yet and just noticed it as I was writing these notes.
# Notes

Begins the building of a MakefileNode that works for NodeJS

Adjusts tests/apitest.js to be dual-mode.

Turns api.js and widgets.js into proper require modules.

Replace references to 'engine._' with 'this._' within api.js. These are probably
mistakes that the previous load() (instead of require()) kept hidden
until I ensured that only exported functions were visible.

Updates README with some clarification of the RingoJS to NodeJS conversion.

Converts more routes to dual-mode.

Disables (via `if (false) {`) the /legacy/XXX and /labs/XXX endpoints.

Adds documentation.

Adds more behave tests.

Adds a behave step that allows single-quotes as delimiters.

Adds maui_utilities.feature to behave tests

Removes all use of RingoJS load().

Fixes webapp to act like a normal require() module. Adds configServer() and startServer() methods to allow control of the config and golrConfig.

Adds stickloader.js to deal per-thread initialization of bbop.monarch.Engine and related data structures.

Adds a logFetchTiming flag to api.js to enable/disable the logging of FETCHING/FETCHED messages.

Enhances logging of FETCH to include elapsed time and length, as well as the cumulative number of FETCH times and lengths.

Adds an env.readJSON() convenience function to read and parse a JSON file.

Updates a few NPM modules to new major versions:
"hapi": "^8.8.0"    -->    "hapi": "^9.3.0",
"chai": "^2.3.0"    -->    "chai": "^3.2.0"
 "del": "^1.1.1" -->        "del": "^2.0.1",
