### PR TITLE
Updates followed by Phenogrid 1.1.0

### DIFF
--- a/js/Analyze.js
+++ b/js/Analyze.js
@@ -728,16 +728,6 @@ function AnalyzeInit(uploaded_data){
         
 
         var phenotypes  = text.split(/[\s,]+/);
-        // Old way - Zhou
-	/*
-	$("#phen_vis").phenogrid({
-				phenotypeData: phenotypes,
-				targetSpeciesName: species,
-				owlSimFunction: urlParams.mode,
-				geneList: urlParams.geneList,
-				providedData: urlParams.user_input
-			});
-	*/	
 
         // New way - Zhou
         // Phenogrid will remove the duplicated phenotypes in this monarch-app returned phenotype_list
@@ -748,10 +738,7 @@ function AnalyzeInit(uploaded_data){
 			targetSpecies: species,
 			owlSimFunction: urlParams.mode,
 			geneList: urlParams.geneList,
-			providedData: urlParams.user_input,
-			imagePath: '/node_modules/phenogrid/image/', // path to external images - Zhou
-			htmlPath: '/node_modules/phenogrid/js/res/' // path to html help text - Zhou
-
+			providedData: urlParams.user_input
 		});
 	};
     }

--- a/js/phenogridloader-no-species.js
+++ b/js/phenogridloader-no-species.js
@@ -16,9 +16,7 @@ function loadPhenogrid(){
             //timeout : 180000,
             error : function(jqXHR, textStatus, errorThrown) {
                 var phenogridOpts = {
-                                        phenotypeData: phenotype_list,
-                                        imagePath: '/node_modules/phenogrid/image/',
-					htmlPath: '/node_modules/phenogrid/js/res/'
+                                        phenotypeData: phenotype_list
                                     };
                 Phenogrid.createPhenogridForElement(phenogridContainer, phenogridOpts);
             },
@@ -27,11 +25,8 @@ function loadPhenogrid(){
                 // before sending the ajax POST to simsearch - Zhou
                 phenotype_list = data.phenotype_list;
 
-                // imagePath and htmlPath will overwrite the imagePath and htmlPath in phenogrid.js
                 var phenogridOpts = {
-                                        phenotypeData: phenotype_list,
-                                        imagePath: '/node_modules/phenogrid/image/', 
-					htmlPath: '/node_modules/phenogrid/js/res/'
+                                        phenotypeData: phenotype_list
                                     };
                 Phenogrid.createPhenogridForElement(phenogridContainer, phenogridOpts);
             }

--- a/js/phenogridloader-onclick.js
+++ b/js/phenogridloader-onclick.js
@@ -27,20 +27,15 @@ function loadPhenogrid(){
             //timeout : 180000,
             error : function(jqXHR, textStatus, errorThrown) {
                 var phenogridOpts = {
-                                        phenotypeData: phenotype_list,
-                                        imagePath: '/node_modules/phenogrid/image/',
-                    htmlPath: '/node_modules/phenogrid/js/res/'
+                                        phenotypeData: phenotype_list
                                     };
                 Phenogrid.createPhenogridForElement(phenogridContainer, phenogridOpts);
             },
             success : function(data) {
                 phenotype_list = data.phenotype_list;
 
-                // imagePath and htmlPath will overwrite the imagePath and htmlPath in phenogrid.js
                 var phenogridOpts = {
-                                        phenotypeData: phenotype_list,
-                                        imagePath: '/node_modules/phenogrid/image/', 
-                    htmlPath: '/node_modules/phenogrid/js/res/'
+                                        phenotypeData: phenotype_list
                                     };
                 Phenogrid.createPhenogridForElement(phenogridContainer, phenogridOpts);
             }

--- a/lib/monarch/web/webapp.js
+++ b/lib/monarch/web/webapp.js
@@ -130,7 +130,6 @@ var pup_tent_dirs = [
                     'node_modules/phenogrid/node_modules/gfm.css', // dist contains phenogrid-bundle.js and phenogrid-bundle.css
                     'node_modules/phenogrid/dist', // dist contains phenogrid-bundle.js and phenogrid-bundle.css
                     'node_modules/phenogrid/config', // config contains phenogrid_config.js
-                    'node_modules/phenogrid/js/res',
                     'widgets/keggerator/js',
                     'widgets/class-enrichment',
                     'conf', // get access to conf/golr-conf.json
@@ -850,15 +849,6 @@ web.wrapRouteGet(app, '/image/team/:page', '/image/team/{page}', ['page'],
         var path = './image/team/'+page;
         var ctype = _decide_content_type(path);
         var s = env.fs_readFileSyncBinary(path) ;
-        return web.wrapBinary(s, ctype);
-    }, errorResponse
-);
-
-web.wrapRouteGet(app, '/node_modules/phenogrid/image/:filename', '/node_modules/phenogrid/image/{filename}', ['filename'],
-    function(request, filename) {
-        var path = './node_modules/phenogrid/image/' + filename;
-        var ctype = _decide_content_type(path);
-        var s = env.fs_readFileSyncBinary(path);
         return web.wrapBinary(s, ctype);
     }, errorResponse
 );

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "lodash": "^3.10.1",
     "lodash._isiterateecall": "^3.0.9",
     "mustache": "^2.1.2",
-    "phenogrid": "^1.0.8",
+    "phenogrid": "^1.1.0",
     "querystring": "^0.2.0",
     "request": "^2.60.0",
     "sax": "^1.1.1",


### PR DESCRIPTION
1. removed the use of `htmlPath` and `imagePath`, phenogrid no longer uses external image files as well as separate html files for popup dialogs
2. updated phenogrid version number to 1.1.0 in package.json to sync with the phenogrid npm updates

@kshefchek @DoctorBud Please review and merge.
