### PR TITLE
Split "slow page" behave test into two steps

### DIFF
--- a/tests/behave/maui_gene.feature
+++ b/tests/behave/maui_gene.feature
@@ -5,6 +5,7 @@ Feature: Gene page description
 
  @ui
  Scenario: text based description of the gene appears in a user-friendly way
-    Given I go to slow page "/gene/OMIM:168600#overview" and wait for id "compare"
+    Given I go to page "/gene/OMIM:168600#overview"
+     then wait for id "compare"
      then the "Overview" tab should contain "Parkinson disease was first described by James Parkinson"
 

--- a/tests/behave/maui_phenogrid.feature
+++ b/tests/behave/maui_phenogrid.feature
@@ -5,7 +5,8 @@ Feature: Phenogrid Works
 
 @ui
 Scenario: Phenotype Analysis Phenogrid works
-    Given I go to slow page "/disease/OMIM:105830" and wait for id "pg_svg"
+    Given I go to page "/disease/OMIM:105830"
+      then wait for id "pg_svg"
       then the title should be "Monarch Disease: Angelman syndrome (OMIM:105830)"
       and the document should contain "Phenotype Similarity Comparison"
 
@@ -16,7 +17,8 @@ Scenario: Documentation example phenogrid appears
 
 @ui
 Scenario: Loading the iframe content for Monarch Phenotype Grid Widget loads a page with the correct title
-   Given I go to slow page "/node_modules/phenogrid/index.html" and wait for id "pg_svg"
+   Given I go to page "/node_modules/phenogrid/index.html"
+     then wait for id "pg_svg"
      then the title should be "Monarch Phenotype Grid Widget"
      and the document should contain "Phenogrid is a Javascript component that visualizes"
      and the document should contain "Phenotype Similarity Comparison"

--- a/tests/behave/steps/selenium-basic.py
+++ b/tests/behave/steps/selenium-basic.py
@@ -21,11 +21,8 @@ def step_impl(context, page):
     # wait = WebDriverWait(driver, 10)
     # element = wait.until(EC.element_to_be_clickable((By.ID,'someid')))
 
-@given('I go to slow page "{page}" and wait for id "{id}"')
-def step_impl(context, page, id):
-    #print(context.browser.title)
-    context.browser.get(context.target + page)
-    time.sleep(5)
+@then('wait for id "{id}"')
+def step_impl(context, id):
     element = WebDriverWait(context.browser, 200).until(EC.presence_of_element_located((By.ID, id)))
     # try:
     #     print(id)


### PR DESCRIPTION
We sometimes have issues with the test 

```
    I go to slow page "{page}" and wait for id "{id}"
```

Where context.browser.get(context.target + page) is called and while the page is loading

```
    element = WebDriverWait(context.browser, 200).until(EC.presence_of_element_located((By.ID, id)))
```

is executed and presence_of_element_located is satisfied by an element loaded from a previous test.  Note that this only seems to be an issue on travis.

This fix splits the test into two independent tests:

```
    I go to page {page}
    then wait for id {id}
```

@doctorbud does this fix make sense?
