### PR TITLE
Add metadata to simsearch and compare json when no results are found

### DIFF
--- a/lib/monarch/api.js
+++ b/lib/monarch/api.js
@@ -4229,8 +4229,15 @@ bbop.monarch.Engine.prototype.makeSimComparisonResults = function(stuff, metric,
     if (stuff.length > 0) {
         system_stats = stuff[0].system_stats;
     }
-    //console.log(JSON.stringify(stuff));
     
+    //HARDCODE ALERT
+    //TODO this should be the result of an owlsim call
+    if (system_stats != null && typeof system_stats != 'undefined') {
+        system_stats.metric_stats = {metric : metric, maxscore : '100', avgscore : '60', stdevscore : '4.32', comment:'These stats are approximations for this release'};
+    } else {
+        system_stats = {};
+        system_stats.metric_stats = {metric : metric, maxscore : '100', avgscore : '60', stdevscore : '4.32', comment:'These stats are approximations for this release'};
+    }
     
     for (var i=0; i<stuff.length; i++) {
         // rank is based on rank returned by owlsim, currently hardcoded to be combinedScore
@@ -4264,11 +4271,7 @@ bbop.monarch.Engine.prototype.makeSimComparisonResults = function(stuff, metric,
     };
 
     if (results.length > 0) {
-        //HARDCODE ALERT
-        //TODO this should be the result of an owlsim call
-        if (system_stats != null && typeof system_stats != 'undefined') {
-            system_stats.metric_stats = {metric : metric, maxscore : '100', avgscore : '60', stdevscore : '4.32', comment:'These stats are approximations for this release'};
-        }
+
         var similarThings = {
             b : results,  // TODO: process results to select only a single
                             // metric, reformat, etc.
@@ -4276,7 +4279,9 @@ bbop.monarch.Engine.prototype.makeSimComparisonResults = function(stuff, metric,
             resource : {label:'OwlSim Server: '+this.config.owlsim_services_url},
         };
     } else {
-        var similarThings = {};
+        var similarThings = {
+                metadata : system_stats
+        };
     }
 
     return similarThings;

--- a/tests/behave/maui_utilities.feature
+++ b/tests/behave/maui_utilities.feature
@@ -67,6 +67,7 @@ Feature: NodeJS and RingoJS pass all tests.
     Given I go to page "/compare/HP:0012774+HP:0002650/1232413241234.json"
      then the document should contain "HP:0012774"
      then the document should contain "HP:0002650"
+     then the document should contain '"metric":"combinedScore"'
 
 @ui
 Scenario: The "/query/orthologs/" endpoint returns the correct JSON


### PR DESCRIPTION
See issues #1032 and #1005, this PR adds the metadata field to simsearch and compare results that return no results.
