### PR TITLE
Fix to show owlsim system stats in compare output

### DIFF
--- a/lib/monarch/api.js
+++ b/lib/monarch/api.js
@@ -4227,7 +4227,10 @@ bbop.monarch.Engine.prototype.makeSimComparisonResults = function(stuff, metric,
     var results = [];
     var system_stats = {};
     if (stuff.length > 0) {
-        system_stats = stuff[0].system_stats;
+        var results_with_metadata = stuff.filter(function (i) { return "system_stats" in i;});
+        if (results_with_metadata.length > 0) {
+            system_stats = results_with_metadata[0].system_stats;
+        }
     }
     
     //HARDCODE ALERT

--- a/tests/behave/maui_utilities.feature
+++ b/tests/behave/maui_utilities.feature
@@ -61,7 +61,9 @@ Feature: NodeJS and RingoJS pass all tests.
      then the document should contain "Smith-Lemli-Opitz Syndrome"
      then the document should contain "PDGFRA"
      then the document should contain "Blue irides"
-     
+     then the document should contain "maxSumIC"
+     then the document should contain "meanMaxIC"
+
 @ui
  Scenario: The "/compare/" endpoint returns the correct JSON with invalid ID
     Given I go to page "/compare/HP:0012774+HP:0002650/1232413241234.json"


### PR DESCRIPTION
This is a three line fix to make sure that we are always displaying system stats (from owlsim) metadata in the compare call results when the service returns results.

See: https://github.com/monarch-initiative/monarch-app/pull/1066#issuecomment-155431836
