### PR TITLE
README has better NPM install instructions. Autocomplete menu consistency. CSS cleanup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ below.
     - [Documentation on the Tooling](#documentation-on-the-tooling)
         - [BrowserSync](#browsersync)
 - [Installing NodeJS and NPM for Monarch](#installing-nodejs-and-npm-for-monarch)
-    - [Install via `nvm` (Node Version Manager)](#install-via-nvm-node-version-manager)
+    - [Install NodeJS via `nvm` (Node Version Manager)](#install-nodejs-via-nvm-node-version-manager)
         - [Installing `nvm` on MacOSX via HomeBrew](#installing-nvm-on-macosx-via-homebrew)
         - [Installing `nvm` on MacOSX or Unix via `wget`/`curl`](#installing-nvm-on-macosx-or-unix-via-wgetcurl)
-- [According to the `nvm` site, this script will mod](#according-to-the-nvm-site-this-script-will-mod)
+    - [Installing NodeJS via `n`](#installing-nodejs-via-n)
 - [Legacy RingoJS installation and launch instructions](#legacy-ringojs-installation-and-launch-instructions)
 
 <!-- /MarkdownTOC -->
@@ -234,14 +234,38 @@ Note that your default web browser will open up automatically and you will be po
 
 ## Installing NodeJS and NPM for Monarch
 
-Although your development machine may be running NodeJS and NPM currently, it is likely not the exact same version that Monarch is currently supporting (NodeJS 0.12.2 and NPM 3.4.0). The instructions below may help achieve the proper NodeJS version.
+Although your development machine may be running NodeJS and NPM currently, it is likely not the exact same version that Monarch is currently supporting (NodeJS 0.12.2 and NPM 3.4.0). The instructions below may help achieve the proper NodeJS and NPM versions. If you are not familiar with NodeJS and NPM, then this may help. Otherwise, use your ordinary technique for achieving NodeJS v0.12.2 and NPM v3.4.0 and skip the remainder of this section.
+
+If you are not running a current version of NodeJS, use the instructions below in:
+
+- [Install NodeJS via `nvm` (Node Version Manager)](#install-nodejs-via-nvm-node-version-manager)
+- [Installing NodeJS via `n`](#installing-nodejs-via-n)
+
+Once you have a correct NodeJS version running and selected as the current default for your shell (e.g., `nvm use v0.12.2`), then you can ensure that the correct NPM is installed by using the command:
+
+    > npm install -g npm@3.4.0
+
+Verify that you are running the correct versions by:
+
+    > npm version
+
+which should output something containing:
 
 
-#### Install via `nvm` (Node Version Manager)
 
-One of the easiest ways to install an alternative version of Node is to use the `nvm` tool available at [https://github.com/creationix/nvm](https://github.com/creationix/nvm).
+### Install NodeJS via `nvm` (Node Version Manager)
 
-##### Installing `nvm` on MacOSX via HomeBrew
+One of the easiest ways to install an alternative version of Node is to use the `nvm` tool available at [https://github.com/creationix/nvm](https://github.com/creationix/nvm). If you have `nvm` installed, you can use the following command to installed NodeJS v0.12.2:
+
+    > nvm install v0.12.2
+
+This will download, compile and install the 0.12.2 version of NodeJS into the `~/.nvm` directory, making it *available* for the next command:
+
+    >nvm use v0.12.2
+
+This command will change your current NVM environment so that it *sees* a v0.12.2 version of NodeJS.
+
+#### Installing `nvm` on MacOSX via HomeBrew
 
 If you have MacOSX, and you have [HomeBrew](http://brew.sh) installed, then the following command will be sufficient to install `nvm`:
 
@@ -260,7 +284,7 @@ Follow the instructions printed to your console after the above `brew install nv
 >     source $(brew --prefix nvm)/nvm.sh
 
 
-##### Installing `nvm` on MacOSX or Unix via `wget`/`curl`
+#### Installing `nvm` on MacOSX or Unix via `wget`/`curl`
 
 The instructions on the [`nvm` GitHub Site]() provide a way to install NVM easily; these have been adapted below.
 
@@ -278,12 +302,20 @@ Run the `install.sh` script
 
     > bash install.sh
 
-According to the `nvm` site, this script will mod
+According to the `nvm` site, this script will modify your `.bashrc` or `.bash_profile` automatically. See [Manual Install](https://github.com/creationix/nvm#manual-install) for more information if the above `install.sh` does not work.
+
+
+### Installing NodeJS via `n`
+
+There is a tool called `n` that may be useful for installing the proper NodeJS versions if the `nvm`-based solutions above do not work. You may have also adopted `n` for a different project, in which case it may be used for Monarch.
+
+The `n` tool is available from [https://github.com/tj/n](https://github.com/tj/n) where you can find the necessary instructions.
+
 ---
 
 ## Legacy RingoJS installation and launch instructions
 
-The RingoJS version of Monarch is currently deprecated as we are committed to making the NodeJS experience awesome. It is likely that the RingoJS support for Monarch will be eliminated in the near future. Until then, the following instructions should assist in running the RingoJS version.
+The RingoJS version of Monarch is currently deprecated as we are committed to making the Monarch NodeJS experience great. It is likely that the RingoJS support for Monarch will be eliminated in the near future. Until then, the following instructions should assist in running the RingoJS version.
 
 
 1. Install RingoJS - http://ringojs.org

--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ below.
     - [Running Monarch with `webpack-dev-server`](#running-monarch-with-webpack-dev-server)
     - [Documentation on the Tooling](#documentation-on-the-tooling)
         - [BrowserSync](#browsersync)
+- [Installing NodeJS and NPM for Monarch](#installing-nodejs-and-npm-for-monarch)
+    - [Install via `nvm` (Node Version Manager)](#install-via-nvm-node-version-manager)
+        - [Installing `nvm` on MacOSX via HomeBrew](#installing-nvm-on-macosx-via-homebrew)
+        - [Installing `nvm` on MacOSX or Unix via `wget`/`curl`](#installing-nvm-on-macosx-or-unix-via-wgetcurl)
+- [According to the `nvm` site, this script will mod](#according-to-the-nvm-site-this-script-will-mod)
 - [Legacy RingoJS installation and launch instructions](#legacy-ringojs-installation-and-launch-instructions)
 
 <!-- /MarkdownTOC -->
@@ -56,7 +61,7 @@ Monarch now uses up-to-date NPM modules to provide common libraries such as jQue
 
 The Monarch web application was designed to support the integration of diverse JavaScript libraries and HTML fragments. This was to encourage experimentation with different visualization frameworks and technology. The Monarch web application associates a given route (e.g., `/page/about`) with a handler that generates the correct webpage by assembling pieces via the server-side pup-tent library. This allows different web pages within the Monarch app to have completely different Javascript and CSS resources, and has been useful in the development of Monarch's features.
 
-Recently, we have been evolving the codebase to support modern web front-end tooling, including the use of preprocessors (e.g., LESS, JSHint), the bundling and minification of JS and CSS resources, and a more rapid development cycle. In the short term, we expect this will result in more effective and pleasant development experience, as well as a more efficient web application. In the longer term, we may choose to build Monarch as a single-page app, in which case this bundling is essential.
+Recently, we have been evolving the codebase to support modern web front-end tooling, including the use of preprocessors (e.g., LESS, JSHint), the bundling and minification of JS and CSS resources, and a more rapid development cycle. In the short term, we expect this will result in more effective and pleasant development experience, as well as a more efficient web application. In the longer term, this will enable us to build parts of the Monarch UI as a single-page app.
 
 Details on how to use the new tech are later in this document at [New UI Tools and Bundling Instructions](#new-ui-tools-and-bundling-instructions).
 
@@ -76,9 +81,12 @@ You will need to have NodeJS and NPM installed. At the time of this writing, we 
         ...
           node: '0.12.2',
 
-About Node Versioning: Node 4.x is the immediate successor to the 0.12.x version of NodeJS. The version number jumped from 0.12.2 to 4.0.0 as a result of the NodeJS committee adjusting their version-numbering system recently. More information is in the [V4.0 Release Notes](https://nodejs.org/en/blog/release/v4.0.0/).
+*About Node Versioning*: Node 4.x is the immediate successor to the 0.12.x version of NodeJS. The version number jumped from 0.12.2 to 4.0.0 as a result of the NodeJS committee adjusting their version-numbering system recently. More information is in the [V4.0 Release Notes](https://nodejs.org/en/blog/release/v4.0.0/).
 
 We are currently holding at 0.12.2 and HapiJS 11.0.2 due to GCC version issues on some of our CentOS deployment nodes. When we are able to update these nodes to GCC 4.8, then we can update package.json to reflect Node 4.2.x and HapiJS 11.1.x, which are the current stable and supported versions of these packages.
+
+Currently, we have been successfully using the `nvm` tool to configure and manage our NodeJS environment; `nvm` enables a user to associate a paritcular  NodeJS and NPM version with their Unix shell, allowing for each switching between NodeJS versions across different projects. If you need help in getting the Monarch-required NodeJS and NPM versions installed, please read the platform-specific instructions on installing NodeJS and NPM, see [Installing NodeJS and NPM for Monarch](#installing-nodejs-and-npm-for-monarch) below.
+
 
 ### Download and Install Monarch
 
@@ -223,9 +231,60 @@ Note that your default web browser will open up automatically and you will be po
 [`webpack-dev-server`](https://webpack.github.io/docs/webpack-dev-server.html) is a NodeJS server that integrates with WebPack to deliver bundled assets incrementally to a web browser during active development. It enables a developer to see the effect of their changes immediately in the browser, and then later they can perform the slower and more thorough `npm run build` operation.
 
 
+
+## Installing NodeJS and NPM for Monarch
+
+Although your development machine may be running NodeJS and NPM currently, it is likely not the exact same version that Monarch is currently supporting (NodeJS 0.12.2 and NPM 3.4.0). The instructions below may help achieve the proper NodeJS version.
+
+
+#### Install via `nvm` (Node Version Manager)
+
+One of the easiest ways to install an alternative version of Node is to use the `nvm` tool available at [https://github.com/creationix/nvm](https://github.com/creationix/nvm).
+
+##### Installing `nvm` on MacOSX via HomeBrew
+
+If you have MacOSX, and you have [HomeBrew](http://brew.sh) installed, then the following command will be sufficient to install `nvm`:
+
+    > brew install nvm
+
+Follow the instructions printed to your console after the above `brew install nvm`. The most important part of the instructions are:
+
+>   You should create NVM's working directory if it doesn't exist:
+>
+>     mkdir ~/.nvm
+>
+>   Add the following to ~/.bash_profile or your desired shell
+>   configuration file:
+>
+>     export NVM_DIR=~/.nvm
+>     source $(brew --prefix nvm)/nvm.sh
+
+
+##### Installing `nvm` on MacOSX or Unix via `wget`/`curl`
+
+The instructions on the [`nvm` GitHub Site]() provide a way to install NVM easily; these have been adapted below.
+
+Download `install.sh` via `curl`:
+
+    > cd /tmp
+    > curl -O https://raw.githubusercontent.com/creationix/nvm/v0.29.0/install.sh
+
+Alternatively, download `install.sh` via `wget`:
+
+    > cd /tmp
+    > curl -O https://raw.githubusercontent.com/creationix/nvm/v0.29.0/install.sh
+
+Run the `install.sh` script
+
+    > bash install.sh
+
+According to the `nvm` site, this script will mod
 ---
 
 ## Legacy RingoJS installation and launch instructions
+
+The RingoJS version of Monarch is currently deprecated as we are committed to making the NodeJS experience awesome. It is likely that the RingoJS support for Monarch will be eliminated in the near future. Until then, the following instructions should assist in running the RingoJS version.
+
 
 1. Install RingoJS - http://ringojs.org
 

--- a/css/bbop.css
+++ b/css/bbop.css
@@ -66,7 +66,6 @@
  * Make the ajax a little more pleasant if available.
  */
 .ui-autocomplete-loading {
-    border:1px solid green !important;
     background: white url('/images/waiting_ac.gif') right center no-repeat;
 }
 .ui-ajax-loading {

--- a/css/monarch-common.css
+++ b/css/monarch-common.css
@@ -139,9 +139,6 @@ p.bigfont {
     margin-right: 5px;
 }
 
-
-
-
 .input-group {
     margin-bottom: 0px;
 }
@@ -149,43 +146,6 @@ p.bigfont {
     padding: 0px 10px;
     border-radius: 2px;
 }
-
-/*
-@media (max-width: 900px) {
-    .navbar {
-        min-height: 40px;
-    }
-    .monarch-navbar-container {
-        margin: 0px -3px;
-    }
-    .navbar-brand {
-        padding: 8px 5px 0px 20px;
-    }
-
-    .collapse.in{
-        display:block !important;
-    }
-
-    .navbar-brand {
-        padding: 15px;
-    }
-    .nav.navbar-nav {
-        margin: 0px 0 10px;
-    }
-    .nav>li>a {
-        padding: 5px 10px;
-        margin: 0 10px;
-        border-radius: 0px;
-    }
-    .navbar-nav>li>.dropdown-menu {
-        margin-top: 0px;
-        margin-left: 10px;
-    }
-    .navbar-form {
-        margin-top: 0px;
-    }
-}
-*/
 
 
 @media (max-width: 900px) {
@@ -275,8 +235,6 @@ p.bigfont {
     padding: 36px 0px 0px;
     height: 100%;
 }
-
-
 
 .content {
     display: inline-block;
@@ -398,22 +356,6 @@ p.bigfont {
     border:1px solid black;
 }
 
-
-/* Rest of Content */
-/* This overrides Bootstrap content styles. */
-
-.ui-autocomplete {
-    background: white;
-    position:absolute;
-    cursor:default;
-    z-index:4000 !important
-}
-.bbop-js-ui-hoverable{
-    cursor: text;
-}
-
-
-
 /* Buttons */
 /* These styles override some bootstrap button styles to make the buttons slimmer
  * and less skeuomorphic. */
@@ -478,14 +420,31 @@ h1.downloadline {
 
 /* Search Bar */
 
-.ui-autocomplete .autocomplete-tag-item {
+#monarch-body .ui-autocomplete {
+    position:absolute;
+    line-height: 22px;
+    cursor:default;
     white-space: nowrap;
-    font-size: 75%;
+    font-size: 100%;
+    color: #888888;
+    z-index:8000 !important;
+    padding: 0;
+    background: #DDD;
+    list-style-type: none;
+    text-decoration: none !important;
+}
+
+#monarch-body .form-control.ui-autocomplete-input.ui-autocomplete-loading {
+    background: white url('../image/waiting_ac.gif') 95% center no-repeat !important;
+}
+
+#monarch-body .ui-autocomplete .autocomplete-tag-item {
+    white-space: nowrap;
     color: #888888;
 }
-/* Get a spinner for jQuery autocomplete wait. */
-.ui-autocomplete .ui-autocomplete-loading {
-    background: white url('../image/waiting_ac.gif') 95% center no-repeat !important;
+
+.bbop-js-ui-hoverable{
+    cursor: text;
 }
 
 .ui-score-spinner {
@@ -499,7 +458,6 @@ h1.downloadline {
     height:28px;
     border-radius: 2px;
 }
-*/
 
 /* Analyze Page */
 
@@ -953,3 +911,206 @@ a:hover .hilite, a:active .hilite {
   border: none;
   background: transparent;
 }
+
+
+
+/*
+    Everything below is ripped from the jquery-ui-modified.js in the phenogrid
+    project. This is necessary because the phenogrid css pollutes the global
+    CSS namespace and Monarch has come to rely upon this variant CSS.
+
+    Phenogrid should be fixed so that it uses a similar jQueryUI version
+    as Monarch-app and that any customizations are qualified with a phenogrid-specific
+    class or id.
+*/
+
+
+/* Component containers
+----------------------------------*/
+#monarch-body .ui-widget {
+    font-family: Trebuchet MS,Tahoma,Verdana,Arial,sans-serif;
+    font-size: 1.1em;
+}
+#monarch-body .ui-widget .ui-widget {
+    font-size: 1em;
+}
+#monarch-body .ui-widget input,
+#monarch-body .ui-widget select,
+#monarch-body .ui-widget textarea,
+#monarch-body .ui-widget button {
+    font-family: Trebuchet MS,Tahoma,Verdana,Arial,sans-serif;
+    font-size: 1em;
+}
+#monarch-body .ui-widget-content {
+    border: 1px solid #dddddd;
+    background: #eeeeee;
+    color: #333333;
+}
+#monarch-body .ui-widget-content a {
+    color: #333333;
+    display: block;
+    text-decoration: none;
+    padding: 3px;
+}
+#monarch-body .ui-widget-header {
+    border: 1px solid #e78f08;
+    background: #f6a828;
+    color: #ffffff;
+    font-weight: bold;
+}
+#monarch-body .ui-widget-header a {
+    color: #ffffff;
+}
+
+/* Interaction states
+----------------------------------*/
+#monarch-body .ui-state-default,
+#monarch-body .ui-widget-content .ui-state-default,
+#monarch-body .ui-widget-header .ui-state-default {
+    border: 1px solid #cccccc;
+    background: #f6f6f6;
+    font-weight: bold;
+    color: #1c94c4;
+}
+#monarch-body .ui-state-default a,
+#monarch-body .ui-state-default a:link,
+#monarch-body .ui-state-default a:visited {
+    color: #1c94c4;
+    text-decoration: none;
+}
+#monarch-body .ui-state-hover,
+#monarch-body .ui-widget-content .ui-state-hover,
+#monarch-body .ui-widget-header .ui-state-hover,
+#monarch-body .ui-state-focus,
+#monarch-body .ui-widget-content .ui-state-focus,
+#monarch-body .ui-widget-header .ui-state-focus {
+    border: 1px solid #fbcb09;
+    background: #fdf5ce;
+    font-weight: bold;
+    color: #c77405;
+}
+#monarch-body .ui-state-hover a,
+#monarch-body .ui-state-hover a:hover,
+#monarch-body .ui-state-hover a:link,
+#monarch-body .ui-state-hover a:visited,
+#monarch-body .ui-state-focus a,
+#monarch-body .ui-state-focus a:hover,
+#monarch-body .ui-state-focus a:link,
+#monarch-body .ui-state-focus a:visited {
+    color: #c77405;
+    text-decoration: none;
+}
+#monarch-body .ui-state-active,
+#monarch-body .ui-widget-content .ui-state-active,
+#monarch-body .ui-widget-header .ui-state-active {
+    border: 1px solid #fbd850;
+    background: #ffffff;
+    font-weight: bold;
+    color: #eb8f00;
+}
+#monarch-body .ui-state-active a,
+#monarch-body .ui-state-active a:link,
+#monarch-body .ui-state-active a:visited {
+    color: #eb8f00;
+    text-decoration: none;
+}
+
+/* Interaction Cues
+----------------------------------*/
+#monarch-body .ui-state-highlight,
+#monarch-body .ui-widget-content .ui-state-highlight,
+#monarch-body .ui-widget-header .ui-state-highlight {
+    border: 1px solid #fed22f;
+    background: #ffe45c;
+    color: #363636;
+}
+#monarch-body .ui-state-highlight a,
+#monarch-body .ui-widget-content .ui-state-highlight a,
+#monarch-body .ui-widget-header .ui-state-highlight a {
+    color: #363636;
+}
+#monarch-body .ui-state-error,
+#monarch-body .ui-widget-content .ui-state-error,
+#monarch-body .ui-widget-header .ui-state-error {
+    border: 1px solid #cd0a0a;
+    background: #b81900;
+    color: #ffffff;
+}
+#monarch-body .ui-state-error a,
+#monarch-body .ui-widget-content .ui-state-error a,
+#monarch-body .ui-widget-header .ui-state-error a {
+    color: #ffffff;
+}
+#monarch-body .ui-state-error-text,
+#monarch-body .ui-widget-content .ui-state-error-text,
+#monarch-body .ui-widget-header .ui-state-error-text {
+    color: #ffffff;
+}
+#monarch-body .ui-priority-primary,
+#monarch-body .ui-widget-content .ui-priority-primary,
+#monarch-body .ui-widget-header .ui-priority-primary {
+    font-weight: bold;
+}
+#monarch-body .ui-priority-secondary,
+#monarch-body .ui-widget-content .ui-priority-secondary,
+#monarch-body .ui-widget-header .ui-priority-secondary {
+    opacity: .7;
+    filter:Alpha(Opacity=70); /* support: IE8 */
+    font-weight: normal;
+}
+#monarch-body .ui-state-disabled,
+#monarch-body .ui-widget-content .ui-state-disabled,
+#monarch-body .ui-widget-header .ui-state-disabled {
+    opacity: .35;
+    filter:Alpha(Opacity=35); /* support: IE8 */
+    background-image: none;
+}
+#monarch-body .ui-state-disabled .ui-icon {
+    filter:Alpha(Opacity=35); /* support: IE8 - See #6059 */
+}
+
+
+/* Misc visuals
+----------------------------------*/
+
+/* Corner radius */
+#monarch-body .ui-corner-all,
+#monarch-body .ui-corner-top,
+#monarch-body .ui-corner-left,
+#monarch-body .ui-corner-tl {
+    border-top-left-radius: 4px;
+}
+#monarch-body .ui-corner-all,
+#monarch-body .ui-corner-top,
+#monarch-body .ui-corner-right,
+#monarch-body .ui-corner-tr {
+    border-top-right-radius: 4px;
+}
+#monarch-body .ui-corner-all,
+#monarch-body .ui-corner-bottom,
+#monarch-body .ui-corner-left,
+#monarch-body .ui-corner-bl {
+    border-bottom-left-radius: 4px;
+}
+#monarch-body .ui-corner-all,
+#monarch-body .ui-corner-bottom,
+#monarch-body .ui-corner-right,
+#monarch-body .ui-corner-br {
+    border-bottom-right-radius: 4px;
+}
+
+/* Overlays */
+#monarch-body .ui-widget-overlay {
+    background: #666666;
+    opacity: .5;
+    filter: Alpha(Opacity=50); /* support: IE8 */
+}
+#monarch-body .ui-widget-shadow {
+    margin: -5px 0 0 -5px;
+    padding: 5px;
+    background: #000000;
+    opacity: .2;
+    filter: Alpha(Opacity=20); /* support: IE8 */
+    border-radius: 5px;
+}
+

--- a/js/index.js
+++ b/js/index.js
@@ -33,10 +33,9 @@ import './search-results.js';
 import './monarch-tabs.js';
 
 import '../css/monarch.less';
-import '../css/monarch-specific.css';
-import '../css/monarch-main.css';
-import '../css/monarch-home.css';
 import '../css/monarch-common.css';
+import '../css/monarch-specific.css';
+import '../css/monarch-home.css';
 
 //console.log('before import bbop:', Object.keys(bbop));
 import _bbop from 'bbop';

--- a/lib/monarch/web/webapp.js
+++ b/lib/monarch/web/webapp.js
@@ -35,7 +35,7 @@
                 if ((page !== 'software')){
                     info.pup_tent_css_libraries.push("/tour.css");
                 } else {
-                    info.pup_tent_css_libraries.push("/monarch-main.css");
+                    info.pup_tent_css_libraries.push("/monarch-example.css");
                 }
 
                 var output = pup_tent.render(page+'.mustache',info);
@@ -305,7 +305,6 @@ else {
         // '/bootstrap-theme.css',
         '/jquery-ui.css',
         '/monarch-common.css',
-        '/monarch-main.css',
         '/monarch-specific.css'
         ]);
 
@@ -518,7 +517,6 @@ var engine;
 function staticTemplate(t) {
     var info = newInfo();
     addCoreRenderers(info);
-    //info.pup_tent_css_libraries.push("/monarch-main.css");
     var output = pup_tent.render(t+'.mustache',info);
     return output;
 }
@@ -804,7 +802,6 @@ function errorResponse(errorStatus, errorMessage) {
     //info.message = JSON.stringify(errorMessage, null, ' ');
     info.stackTrace = stm;
     info.message = errorMessage;
-    //info.pup_tent_css_libraries.push("/monarch-main.css");
     info.title = (errorStatus === 404) ? 'Page Not Found' : 'Error';
     info.debug = !engine.isProduction();
     var template = (errorStatus === 404) ? 'notfound.mustache' : 'error.mustache';
@@ -877,7 +874,6 @@ app.get('/labs/old-home', function(request) {
     addCoreRenderers(info);
 
     info.pup_tent_css_libraries = [
-        '/monarch-main.css',
         '/main.css'
     ];
     info.title = 'Monarch Diseases and Phenotypes';
@@ -893,7 +889,6 @@ function pageByPageHandler(request, page) {
     if ((page !== 'software')){
         info.pup_tent_css_libraries.push("/tour.css");
     } else {
-        //info.pup_tent_css_libraries.push("/monarch-main.css");
     }
     var pageTitles = {
         about: 'About Monarch',
@@ -1431,7 +1426,6 @@ app.get('/legacy/disease/:id.:fmt?', function(request, id, fmt) {
         addCoreRenderers(info, 'disease', id);
 
         //Add pup_tent libs
-        // info.pup_tent_css_libraries.push("/monarch-main.css");
         // info.pup_tent_css_libraries.push("/monarch-specific.css");
         info.pup_tent_css_libraries.push("/imagehover.css");
 
@@ -1716,7 +1710,6 @@ app.get('/legacy/phenotype/:id.:fmt?', function(request, id, fmt) {
         };
         addCoreRenderers(info);
         info.title = info.message;
-        //info.pup_tent_css_libraries.push("/monarch-main.css");
         var output = pup_tent.render('underconstruction.mustache',info,'monarch_base.mustache');
         var res =  response.html(output);
         res.status = 404;
@@ -1739,7 +1732,6 @@ app.get('/legacy/phenotype/:id.:fmt?', function(request, id, fmt) {
         addCoreRenderers(info, 'phenotype', id);
 
         //Add pup_tent libs
-        // info.pup_tent_css_libraries.push("/monarch-main.css");
         // info.pup_tent_css_libraries.push("/monarch-specific.css");
 
         // info.pup_tent_js_libraries.push("/stupidtable.min.js");
@@ -1812,7 +1804,6 @@ var fetchLegacyGenotypePage = function(request, id, fmt) {
         addCoreRenderers(info, 'genotype', id);
 
         //Add pup_tent libs
-        // info.pup_tent_css_libraries.push("/monarch-main.css");
         // info.pup_tent_css_libraries.push("/monarch-specific.css");
         info.pup_tent_css_libraries.push("/imagehover.css");
 
@@ -1948,7 +1939,6 @@ function modelByIdHandler(request, id, fmt) {
         addCoreRenderers(info, 'model', id);
 
         addGolrStaticFiles(info);
-        // info.pup_tent_css_libraries.push("/monarch-main.css");
         // info.pup_tent_css_libraries.push("/monarch-specific.css");
 
         //Load variables for client side tables
@@ -2085,7 +2075,6 @@ function genotypeByIdHandler(request, id, fmt) {
         addCoreRenderers(info, 'genotype', id);
 
         addGolrStaticFiles(info);
-        // info.pup_tent_css_libraries.push("/monarch-main.css");
         // info.pup_tent_css_libraries.push("/monarch-specific.css");
 
         //Load variables for client side tables
@@ -2290,7 +2279,6 @@ app.get('/legacy/gene/:id.:fmt?', function(request, id, fmt) {
     addCoreRenderers(info, 'gene', id);
 
     //Add pup_tent libs
-    // info.pup_tent_css_libraries.push("/monarch-main.css");
     // info.pup_tent_css_libraries.push("/monarch-specific.css");
     info.pup_tent_css_libraries.push("/imagehover.css");
 
@@ -2723,7 +2711,6 @@ function anatomyByIdHandler(request, id, fmt) {
     addCoreRenderers(info, 'anatomy', id);
 
     //Add pup_tent libs
-    // info.pup_tent_css_libraries.push("/monarch-main.css");
     // info.pup_tent_css_libraries.push("/monarch-specific.css");
 
     // info.pup_tent_js_libraries.push("/stupidtable.min.js");
@@ -2781,7 +2768,6 @@ function literatureByIdHandler(request, id, fmt) {
     addCoreRenderers(info, 'literature', id);
 
     //Add pup_tent libs
-    // info.pup_tent_css_libraries.push("/monarch-main.css");
     // info.pup_tent_css_libraries.push("/monarch-specific.css");
 
     // info.pup_tent_js_libraries.push("/stupidtable.min.js");
@@ -3042,7 +3028,6 @@ function annotateTextHandler(request) {
 
     addCoreRenderers(info, 'annotate');
 
-    // info.pup_tent_css_libraries.push("/monarch-main.css");
     // info.pup_tent_css_libraries.push("/monarch-specific.css");
     info.pup_tent_css_libraries.push("/annotate.css");
     info.pup_tent_css_libraries.push("/imagehover.css");
@@ -3219,7 +3204,6 @@ web.wrapRouteGet(app, '/labs/golr/:id', '/labs/golr/{id}', ['id'],
 
         addCoreRenderers(info, 'generic', id);
         addGolrStaticFiles(info);
-        // info.pup_tent_css_libraries.push("/monarch-main.css");
         // info.pup_tent_css_libraries.push("/monarch-specific.css");
 
         //Load variables for client side tables
@@ -3264,8 +3248,6 @@ app.get('/labs/dovegraph.:fmt?',function(request,fmt){
         info.pup_tent_js_libraries.push("/tree.js");
         info.pup_tent_js_libraries.push("/tree_builder.js");
         info.pup_tent_css_libraries.push("/monarch-labs.css");
-        info.pup_tent_css_libraries.push("/monarch-specific.css");
-        info.pup_tent_css_libraries.push("/monarch-main.css");
         info.pup_tent_css_libraries.push("/monarch-specific.css");
         info.pup_tent_css_libraries.push("/main.css");
         info.title = 'Monarch Labs DoveGraph';
@@ -3741,7 +3723,6 @@ function phenotypeByIdHandler(request, id, fmt){
 
             addCoreRenderers(info, 'phenotype', id);
             addGolrStaticFiles(info);
-            // info.pup_tent_css_libraries.push("/monarch-main.css");
             // info.pup_tent_css_libraries.push("/monarch-specific.css");
 
             //Load variables for client side tables
@@ -3877,7 +3858,6 @@ function diseaseByIdHandler(request, id, fmt) {
     addCoreRenderers(info, 'disease', id);
 
     addGolrStaticFiles(info);
-    // info.pup_tent_css_libraries.push("/monarch-main.css");
     // info.pup_tent_css_libraries.push("/monarch-specific.css");
 
     //Load variables for client side tables
@@ -4089,7 +4069,6 @@ function geneByIdHandler(request, id, fmt) {
 
         addCoreRenderers(info, 'gene', id);
         addGolrStaticFiles(info);
-        // info.pup_tent_css_libraries.push("/monarch-main.css");
         // info.pup_tent_css_libraries.push("/monarch-specific.css");
 
         //Load variables for client side tables
@@ -4299,7 +4278,6 @@ function variantByIdHandler(request, id, fmt) {
 
         addCoreRenderers(info, 'variant', id);
         addGolrStaticFiles(info);
-        // info.pup_tent_css_libraries.push("/monarch-main.css");
         // info.pup_tent_css_libraries.push("/monarch-specific.css");
 
         //Load variables for client side tables
@@ -4454,7 +4432,6 @@ app.get('/labs/case/:id', function(request, id, fmt){
     info.hasPhenotypes = true;
     info.includes.phenogrid_anchor = expandTemplate('phenogrid-anchor', info);
 
-    // info.pup_tent_css_libraries.push("/monarch-main.css");
     // info.pup_tent_css_libraries.push("/monarch-specific.css");
 
     info.hasRelated = function() {return checkExistence(info.related)};
@@ -4505,7 +4482,6 @@ function associationByIdHandler(request, id, fmt){
 
             addCoreRenderers(info, 'association', id);
             addGolrStaticFiles(info);
-            // info.pup_tent_css_libraries.push("/monarch-main.css");
             // info.pup_tent_css_libraries.push("/monarch-specific.css");
             info.type = "Association";
 
@@ -4826,7 +4802,6 @@ app.get('/labs/gene/:id.:fmt?', function(request, id, fmt) {
     addCoreRenderers(info, 'gene', id);
 
     //Add pup_tent libs
-    // info.pup_tent_css_libraries.push("/monarch-main.css");
     // info.pup_tent_css_libraries.push("/monarch-specific.css");
     info.pup_tent_css_libraries.push("/imagehover.css");
 
@@ -4966,7 +4941,6 @@ function analyzeByDatatypePostHandler(request, datatype, fmt) {
      addCoreRenderers(info, 'analyze', datatype);
 
      //Add pup_tent libs
-     // info.pup_tent_css_libraries.push("/monarch-main.css");
      // info.pup_tent_css_libraries.push("/monarch-specific.css");
      info.pup_tent_css_libraries.push("/imagehover.css");
 
@@ -5093,7 +5067,6 @@ function analyzeByDatatypeGetHandler(request, datatype, fmt) {
      addCoreRenderers(info, 'analyze', datatype);
 
      //Add pup_tent libs
-     // info.pup_tent_css_libraries.push("/monarch-main.css");
      // info.pup_tent_css_libraries.push("/monarch-specific.css");
      info.pup_tent_css_libraries.push("/imagehover.css");
 

--- a/lib/monarch/web/webapp.js
+++ b/lib/monarch/web/webapp.js
@@ -1398,6 +1398,7 @@ function diseaseLandingHandler(request) {
 }
 
 web.wrapRouteGet(app, '/disease', '/disease', [], diseaseLandingHandler, errorResponse);
+web.wrapRouteGet(app, '/disease/', '/disease/', [], diseaseLandingHandler, errorResponse);
 
 if (false) { /* Disabling all /legacy/xxx and /labs/xxx endpoints that aren't dual-mode */
 // DISEASE PAGE
@@ -1697,6 +1698,7 @@ function phenotypeLandingHandler(request) {
 }
 
 web.wrapRouteGet(app, '/phenotype', '/phenotype', [], phenotypeLandingHandler, errorResponse);
+web.wrapRouteGet(app, '/phenotype/', '/phenotype/', [], phenotypeLandingHandler, errorResponse);
 
 
 if (false) { /* Disabling all /legacy/xxx and /labs/xxx endpoints that aren't dual-mode */
@@ -2248,6 +2250,7 @@ function geneLandingPageHandler(request) {
 }
 
 web.wrapRouteGet(app, '/gene', '/gene', [], geneLandingPageHandler, errorResponse);
+web.wrapRouteGet(app, '/gene/', '/gene/', [], geneLandingPageHandler, errorResponse);
 
 
 
@@ -2475,7 +2478,9 @@ function modelLandingPageHandler(request){
 }
 
 web.wrapRouteGet(app, '/model', '/model', [], modelLandingPageHandler, errorResponse);
+web.wrapRouteGet(app, '/model/', '/model/', [], modelLandingPageHandler, errorResponse);
 web.wrapRouteGet(app, '/genotype', '/genotype', [], genotypeLandingPageHandler, errorResponse);
+web.wrapRouteGet(app, '/genotype/', '/genotype/', [], genotypeLandingPageHandler, errorResponse);
 
 
 function getGeneMapping(id) {
@@ -2942,6 +2947,8 @@ function simsearchPhenotypeByTargetTypeLimitItemsHandler(request) {
 
 web.wrapRouteGet(app, '/simsearch/phenotype', '/simsearch/phenotype', [], simsearchPhenotypeByTargetTypeLimitItemsHandler, errorResponse);
 web.wrapRoutePost(app, '/simsearch/phenotype', '/simsearch/phenotype', [], simsearchPhenotypeByTargetTypeLimitItemsHandler, errorResponse);
+web.wrapRouteGet(app, '/simsearch/phenotype/', '/simsearch/phenotype/', [], simsearchPhenotypeByTargetTypeLimitItemsHandler, errorResponse);
+web.wrapRoutePost(app, '/simsearch/phenotype/', '/simsearch/phenotype/', [], simsearchPhenotypeByTargetTypeLimitItemsHandler, errorResponse);
 
 
 function annotateTextHandler(request) {

--- a/lib/monarch/web/webapp_launcher.js
+++ b/lib/monarch/web/webapp_launcher.js
@@ -35,6 +35,9 @@ if (envName === 'production') {
 else if (envName === 'stage') {
 	defaultConfigFile = "conf/server_config_stage.json";
 }
+// else if (envName === 'CORSTest') {
+// 	defaultConfigFile = "conf/server_config_cors_test.json";
+// }
 
 console.log('defaultConfigFile: ' + defaultConfigFile + ' golrConfigFile: ' + golrConfigFile);
 

--- a/templates/monarch_base.mustache
+++ b/templates/monarch_base.mustache
@@ -88,7 +88,7 @@ function loader() {
 {{^home_page}}
 <body
 {{/home_page}}
-
+    id="monarch-body"
 {{#useBundle}}
 onload="loaderBody()"
 {{/useBundle}}


### PR DESCRIPTION
- Updates README with nvm and n instructions and better install instructions.
- Fixes monarch-common.css to override jquery-ui styles in the same way that phenogrid's jquery-ui-modified.css does, but to use explicit selectors to reduce non-deterministic CSS matching.
- This fixes the autocomplete menus throughout monarch to be consistent with each other.
- Deletes monarch-main.css.
- Adds route aliases for slash-terminated landing pages like /disease and /disease/. Same with /simsearch/phenotype.
