### PR TITLE
Use node_modules/webpack/bin/webpack.js instead of the globally installed webpack

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -22,4 +22,4 @@ echo "# Versions OK, continuing with installation."
 npm install
 ./node_modules/.bin/gulp assemble
 rm -rf dist/*
-webpack --config webpack.build.js --bail -p
+./node_modules/webpack/bin/webpack.js --config webpack.build.js --bail

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "main": "lib/monarch/web/webapp_launcher.js",
   "scripts": {
     "brun": "npm run build && npm run bstart",
-    "build": "rm -rf dist/* && webpack --config webpack.build.js --bail -p",
-    "fastbuild": "webpack --config webpack.build.js --bail -d",
+    "build": "rm -rf dist/* && ./node_modules/webpack/bin/webpack.js --config webpack.build.js --bail -p",
+    "fastbuild": "./node_modules/webpack/bin/webpack.js --config webpack.build.js --bail -d",
     "start": "NODE_PATH=./lib/monarch node lib/monarch/web/webapp_launcher.js",
     "bstart": "USE_BUNDLE=1 NODE_PATH=./lib/monarch node lib/monarch/web/webapp_launcher.js",
     "rstart": "./ringo-server.sh",


### PR DESCRIPTION
Use node_modules/webpack/bin/webpack.js instead of the globally installed webpack

This should work better on Bamboo, where we cannot make the assumption that someone did a `npm install -g webpack` prior. It also is better practice to use only stuff referred to in your package.json, to ensure that everyone is using the same version.
