### PR TITLE
fixes an interaction between the eslint checking during build and the…

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,3 +325,4 @@ The RingoJS version of Monarch is currently deprecated as we are committed to ma
 2. Run app
 
     ./ringo-server.sh
+

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "fastbuild": "node_modules/webpack/bin/webpack.js --config webpack.build.js --bail -d",
     "start": "NODE_PATH=lib/monarch node lib/monarch/web/webapp_launcher.js",
     "bstart": "USE_BUNDLE=1 NODE_PATH=lib/monarch node lib/monarch/web/webapp_launcher.js",
+    "bstartp": "USE_BUNDLE=1 NODE_PATH=lib/monarch node lib/monarch/web/webapp_launcher.js production",
+    "bstarts": "USE_BUNDLE=1 NODE_PATH=lib/monarch node lib/monarch/web/webapp_launcher.js stage",
     "rstart": "./ringo-server.sh",
     "dev": "USE_BUNDLE=1 USE_WEBPACK=1 NODE_PATH=lib/monarch node_modules/nodemon/bin/nodemon.js -d 2 -V -- lib/monarch/web/webapp_launcher.js & node node_modules/.bin/webpack-dev-server --port 8081 --history-api-fallback --hot --inline",
     "devp": "USE_BUNDLE=1 USE_WEBPACK=1 NODE_PATH=lib/monarch node_modules/nodemon/bin/nodemon.js -d 2 -V -- lib/monarch/web/webapp_launcher.js production & node node_modules/.bin/webpack-dev-server --port 8081 --history-api-fallback --hot --inline",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "bstart": "USE_BUNDLE=1 NODE_PATH=lib/monarch node lib/monarch/web/webapp_launcher.js",
     "rstart": "./ringo-server.sh",
     "dev": "USE_BUNDLE=1 USE_WEBPACK=1 NODE_PATH=lib/monarch node_modules/nodemon/bin/nodemon.js -d 2 -V -- lib/monarch/web/webapp_launcher.js & node node_modules/.bin/webpack-dev-server --port 8081 --history-api-fallback --hot --inline",
+    "devp": "USE_BUNDLE=1 USE_WEBPACK=1 NODE_PATH=lib/monarch node_modules/nodemon/bin/nodemon.js -d 2 -V -- lib/monarch/web/webapp_launcher.js production & node node_modules/.bin/webpack-dev-server --port 8081 --history-api-fallback --hot --inline",
     "corstest": "USE_LOG_FETCH=1 USE_BUNDLE=1 USE_WEBPACK=1 NODE_PATH=lib/monarch nodemon -d 2 -V -- lib/monarch/web/webapp_launcher.js CORSTest & node node_modules/.bin/webpack-dev-server --port 8081 --history-api-fallback --hot --inline",
     "test": "make test",
     "rtest": "make -f MakefileRingo test",

--- a/webpack.make.js
+++ b/webpack.make.js
@@ -131,8 +131,15 @@ module.exports = function(options) { // makeWebpackConfig
             cacheDirectory: true,
             presets: ['es2015']
         },
-        include: [monarchJSRoot]
-        //exclude: /(node_modules|js\/d3\.min\.js|js\/jquery-.+)/
+        exclude: [
+          nmRoot,
+          // The following files are excluded from babel processing
+          // because the transformation results in eslint violations.
+          // - jquery.cookie.js is obsoleted by js.cookie.js
+          // - I don't know where stupidtable comes from.
+          path.join(monarchJSRoot, 'jquery.cookie.js'),
+          path.join(monarchJSRoot, 'stupidtable.min.js')
+          ]
       },
 
       {

--- a/webpack.make.js
+++ b/webpack.make.js
@@ -131,14 +131,13 @@ module.exports = function(options) { // makeWebpackConfig
             cacheDirectory: true,
             presets: ['es2015']
         },
+        include: [monarchJSRoot],
         exclude: [
-          nmRoot,
-          // The following files are excluded from babel processing
-          // because the transformation results in eslint violations.
-          // - jquery.cookie.js is obsoleted by js.cookie.js
-          // - I don't know where stupidtable comes from.
-          path.join(monarchJSRoot, 'jquery.cookie.js'),
-          path.join(monarchJSRoot, 'stupidtable.min.js')
+            // The following files are excluded from babel processing
+            // because the transformation results in eslint violations.
+            // - jquery.cookie.js is obsoleted by js.cookie.js
+            // - I don't know where stupidtable comes from.
+            /(jquery.cookie.js|stupidtable.min.js)/
           ]
       },
 


### PR DESCRIPTION
… babel preprocessor. babel was transforming the code into something that didn't pass eslint for stupidtable and jquery.cookie. both of these files are obsolete and should be replaced with their modern counterparts, but this workaround should suffice for now.
