### PR TITLE
Adjusts start-server, webapp, and package.json to make USE_BUNDLE=1 the default. The old behavior can be obtained via 'npm run oldstart'

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ See [bin/README.md](bin/README.md).
 
 ## Non-bundled use of `require.js`
 
-When env variable USE_BUNDLE is not defined or not equal to '1', which we will
+When env variable USE_BUNDLE is set to the value '0', which we will
 call non-bundled or Legacy Mode, the Monarch UI uses
 [RequireJS](http://requirejs.org) to load various JS files and modules, and to
 ensure they are loaded in the correct order.
@@ -173,14 +173,15 @@ ensure they are loaded in the correct order.
 The file `requireconfig.js` is included via `monarch_base.mustache` by RequireJS and this file
 contains a set of `require` statements that include other JS files used by the Monarch front-end.
 
+The default (as of Jan 15, 2016) is that Monarch operates in Bundled Mode unless `USE_BUNDLE=0`.
 
 ## New UI Tools and Bundling Instructions
 
-By default, when you run the Monarch server via `./start-server.sh`, Monarch will operate in non-bundled mode. This means that when the web server delivers a page (e.g., `/page/about`), it will invoke a particular handler in `lib/monarch/web/webapp.js` and that handler (`pageByPageHandler`, in this example) will generate a custom HTML page by expanding a set Mustache templates and streaming the result back to the web browser. The custom HTML page includes CSS and JS file references that support the particular page being delivered.
+By default, when you run the Monarch server via `./start-server.sh`, Monarch will operate in bundled mode. This means that when the web server delivers a page (e.g., `/page/about`), it will invoke a particular handler in `lib/monarch/web/webapp.js` and that handler (`pageByPageHandler`, in this example) will generate a custom HTML page by expanding a set Mustache templates and streaming the result back to the web browser. The custom HTML page includes CSS and JS file references that support the particular page being delivered.
 
 One of the things that Monarch has relied on up to this point is the ability for different handlers to present different CSS and JS files to the browser, enabling us to experiment with diverse libraries and frameworks as we extend and integrate Monarch. Unfortunately, this technique is at odds with many of the goals of delivering a high-performance modern website, which encourages bundling, minification and caching of assets (CSS, JS) in the browser.
 
-We have improved our front-end page generation pipeline to accommodate the current on-the-fly page composition technique as well as to allow for the use of modern tooling to bundle and minify CSS and JS assets for efficient delivery and caching. This bundled mode is disabled by default when Monarch is invoked by `./start-server.sh`, but it can be easily used to speed up front-end development and for the Monarch developers to get an understanding of any pros and cons associated with the bundling and tooling.
+We have improved our front-end page generation pipeline to accommodate the current on-the-fly page composition technique as well as to allow for the use of modern tooling to bundle and minify CSS and JS assets for efficient delivery and caching. This bundled mode is enabled by default when Monarch is invoked by `./start-server.sh`.
 
 ### Running Monarch in Bundled Mode, without `webpack-dev-server`
 
@@ -189,13 +190,13 @@ The bundle behavior is currently controlled via the environment variable `USE_BU
 Here's one way to experiment with the bundled execution:
 
 	> npm run build    # This takes a minute or so, generates dist/app.bundle.* and other dist/*
-	> npm run bstart   # defines USE_BUNDLE=1, then runs webapp_launcher.js
+	> npm run start    # Runs webapp_launcher.js
 
 Alternatively:
 
 	> rm -rf dist/*
 	> webpack --config webpack.build.js --bail -p
-	> USE_BUNDLE=1 NODE_PATH=./lib/monarch node lib/monarch/web/webapp_launcher.js
+	> NODE_PATH=./lib/monarch node lib/monarch/web/webapp_launcher.js
 
 
 ### Running Monarch with `webpack-dev-server`

--- a/install.sh
+++ b/install.sh
@@ -22,4 +22,4 @@ echo "# Versions OK, continuing with installation."
 npm install
 ./node_modules/.bin/gulp assemble
 rm -rf dist/*
-./node_modules/webpack/bin/webpack.js --config webpack.build.js --bail -p
+./node_modules/webpack/bin/webpack.js --config webpack.build.js --bail

--- a/lib/monarch/web/webapp.js
+++ b/lib/monarch/web/webapp.js
@@ -46,9 +46,9 @@
  */
 
 //
-//  The 'useBundle' flag below enables an experimental bundle mode where
+//  The 'useBundle' flag below enables Monarch in bundle mode where
 //  JS and CSS resources are bundled using webpack.
-//  The current default for production should be 'false'
+//  The current default for production should be 'true'
 //
 var env = require('serverenv.js');
 var web = require('web/webenv.js');
@@ -57,12 +57,13 @@ var Mustache = require('mustache');
 var bbop = require('../api.js').bbop;
 
 var useBundle = env.getEnv().USE_BUNDLE;
-if (useBundle && useBundle === '1') {
-    console.log('#USE_BUNDLE enabled');
-    useBundle = true;
+if (useBundle && useBundle === '0') {
+    console.log('#USE_BUNDLE disabled');
+    useBundle = false;
 }
 else {
-    useBundle = false;
+    console.log('#USE_BUNDLE enabled');
+    useBundle = true;
 }
 
 var useWebpack = env.getEnv().USE_WEBPACK;

--- a/package.json
+++ b/package.json
@@ -6,19 +6,14 @@
   "main": "lib/monarch/web/webapp_launcher.js",
   "scripts": {
     "analyze": "rm -rf dist/* && node_modules/webpack/bin/webpack.js --config webpack.build.js --bail --json | analyze-bundle-size",
-    "brun": "npm run build && npm run bstart",
+    "brun": "npm run build && npm run start",
     "build": "rm -rf dist/* && node_modules/webpack/bin/webpack.js --config webpack.build.js --bail",
-    "fastbuild": "node_modules/webpack/bin/webpack.js --config webpack.build.js --bail -d",
     "start": "NODE_PATH=lib/monarch node lib/monarch/web/webapp_launcher.js",
-    "bstart": "USE_BUNDLE=1 NODE_PATH=lib/monarch node lib/monarch/web/webapp_launcher.js",
-    "bstartp": "USE_BUNDLE=1 NODE_PATH=lib/monarch node lib/monarch/web/webapp_launcher.js production",
-    "bstarts": "USE_BUNDLE=1 NODE_PATH=lib/monarch node lib/monarch/web/webapp_launcher.js stage",
-    "rstart": "./ringo-server.sh",
+    "oldstart": "NODE_PATH=lib/monarch USE_BUNDLE=0 node lib/monarch/web/webapp_launcher.js",
     "dev": "scripts/runWebpackDevServer.sh",
     "devp": "scripts/runWebpackDevServer.sh production",
-    "corstest": "USE_LOG_FETCH=1 USE_BUNDLE=1 USE_WEBPACK=1 NODE_PATH=lib/monarch nodemon -d 2 -V -- lib/monarch/web/webapp_launcher.js CORSTest & node node_modules/.bin/webpack-dev-server --port 8081",
+    "corstest": "USE_LOG_FETCH=1 USE_WEBPACK=1 NODE_PATH=lib/monarch nodemon -d 2 -V -- lib/monarch/web/webapp_launcher.js CORSTest & node node_modules/.bin/webpack-dev-server --port 8081",
     "test": "make test",
-    "rtest": "make -f MakefileRingo test",
     "lint": "node_modules/.bin/eslint js/ lib/monarch || exit 0"
   },
   "keywords": [


### PR DESCRIPTION
Adjusts start-server, webapp, and package.json to make USE_BUNDLE=1 the default. The old behavior can be obtained via 'npm run oldstart'
