### PR TITLE
Fixes bug in /reference/:id endpoints where makeExternalURL was undefined.

### DIFF
--- a/lib/monarch/web/webapp.js
+++ b/lib/monarch/web/webapp.js
@@ -140,7 +140,7 @@ var     genTableOfLiteratureGenes = widgets.genTableOfLiteratureGenes;
 var     genTableOfSimilarDiseases = widgets.genTableOfSimilarDiseases;
 var     genTableOfSimilarModels = widgets.genTableOfSimilarModels;
 var     genTableOfSimilarPapers = widgets.genTableOfSimilarPapers;
-
+var     makeExternalURL = widgets.makeExternalURL;
 
 if (env.isRingoJS()) {
   var stick = require('stick');


### PR DESCRIPTION
Fixes bug in /reference/:id endpoints where makeExternalURL was undefined.
