### PR TITLE
Provide global solr variable to client

### DIFF
--- a/lib/monarch/web/webapp.js
+++ b/lib/monarch/web/webapp.js
@@ -549,14 +549,19 @@ function addCoreRenderers(info, type, id, defaults) {
     info.pup_tent_js_variables = [];
 
     // info.pup_tent_js_libraries.push("/facet-filters.js");
-
+       
     //Adding some global app variables
+    var golr_conf_json = env.readJSON('conf/golr-conf.json');
     info.pup_tent_js_variables.push({name:'global_app_base',
         value: engine.config.app_base});
     info.pup_tent_js_variables.push({name:'global_scigraph_url',
         value: engine.config.scigraph_url});
     info.pup_tent_js_variables.push({name:'global_scigraph_data_url',
         value: engine.config.scigraph_data_url});
+    info.pup_tent_js_variables.push({name:'global_solr_url',
+        value: engine.config.golr_url});
+    info.pup_tent_js_variables.push({name:'global_golr_conf',
+        value: golr_conf_json});
 
 
     info.monarch_nav_search_p = true;
@@ -3562,7 +3567,6 @@ app.get('/labs/blog-test', function(request, page){
  */
 
 function addGolrStaticFiles(info) {
-    var golr_conf_json = env.readJSON('conf/golr-conf.json');
     var xrefs_conf_json = env.readJSON('conf/xrefs.json');
 
     if (useBundle) {
@@ -3572,10 +3576,6 @@ function addGolrStaticFiles(info) {
       // info.pup_tent_js_libraries.push("/golr-table.js");
     }
 
-    info.pup_tent_js_variables.push({name:'global_solr_url',
-        value: engine.config.golr_url});
-    info.pup_tent_js_variables.push({name:'global_golr_conf',
-        value: golr_conf_json});
     info.pup_tent_js_variables.push({name:'global_xrefs_conf',
         value: xrefs_conf_json});
 }


### PR DESCRIPTION
Since we are moving to a solr backed autocomplete/search widget, we need to provide the solr url and golr conf files to all pages.
