### PR TITLE
change app base to beta.monarch on beta.monarch

### DIFF
--- a/conf/server_config_beta.json
+++ b/conf/server_config_beta.json
@@ -1,7 +1,7 @@
 {
     "type" : "beta",
     
-    "app_base" : "https://monarchinitiative.org",
+    "app_base" : "https://beta.monarchinitiative.org",
     
     "scigraph_url" : "https://scigraph-ontology.monarchinitiative.org/scigraph/",
 


### PR DESCRIPTION
Changes app_base configuration on beta.monarchinitiative to beta.monarchinitiative, this was possibly changed when we were making the switch to https or for phenogrid.  @yuanzhou @jnguyenx can this be switched back?
