### PR TITLE
Fix json property name (data -> date)

### DIFF
--- a/lib/monarch/web/webapp.js
+++ b/lib/monarch/web/webapp.js
@@ -2966,15 +2966,16 @@ function phenoPacketHandler(request) {
     var status = getStatus();
     
     phenopacket.name = status.name;
-    phenopacket.data = status.date;
+    phenopacket.date = status.date;
     
-    var version = status.offerings.filter(
+    // Comment out until we keep API versions up to date
+    /*var version = status.offerings.filter(
                         offering => offering.name  == 'api_version' 
                             && 'value' in offering);
 
     if (version.length > 0) {
         phenopacket.api_version = version[0].value;
-    }
+    }*/
 
     return web.wrapJSON(phenopacket);
 }


### PR DESCRIPTION
Small fix to phenopacket json property (data should be date).  Also remove monarch api version since this is not up to date.
