### PR TITLE
added mapping from taxid to ID space for C elegans and D melanogaster

### DIFF
--- a/lib/monarch/api.js
+++ b/lib/monarch/api.js
@@ -4059,9 +4059,10 @@ bbop.monarch.Engine.prototype.searchByPhenotypeProfile = function(query,target_s
     var species_to_filter_map = {
             '10090' : { label : 'Mus musculus', target_idspace : 'MGI', b_type : 'gene', b_source : 'nif-0000-00096-6' },
             '9606' : { label : 'Homo sapiens', target_idspace : 'OMIM', b_type : 'disease',b_source : 'nlx_151835-1'},
-            '7227' : { label : 'Drosophila melanogaster', target_idspace : 'FBgenoInternal', b_type : 'genotype',b_source : 'nif-0000-00558-2'},
+            '7227' : { label : 'Drosophila melanogaster', target_idspace : 'FlyBase', b_type : 'gene',b_source : 'nif-0000-00558-2'},
+            '6239' : { label : 'C elegans', target_idspace : 'WB', b_type : 'gene',b_source : 'nif-0000-00558-2'},
             '7955' : { label : 'Danio rerio', target_idspace : 'ZFIN', b_type : 'gene', b_source : 'nif-0000-21427-10'},
-        'UDP': { label :'UDP',target_idspace: 'UDP', b_type:'UDPICS patients',b_source: 'udpics'}
+            'UDP': { label :'UDP',target_idspace: 'UDP', b_type:'UDPICS patients',b_source: 'udpics'}
     };
 
     var resource = {};


### PR DESCRIPTION
side note: we need to get rid of these b_sources to nif. harmless but crufty
