### PR TITLE
Fix virtual window size so that maui_analyze.feature test passes.

### DIFF
--- a/tests/behave/environment.py
+++ b/tests/behave/environment.py
@@ -99,7 +99,7 @@ def before_all(context):
     # Set a 30 second implicit wait - http://selenium-python.readthedocs.org/en/latest/waits.html#implicit-waits
     # Once set, the implicit wait is set for the life of the WebDriver object instance.
     #
-    context.browser.set_window_size(1200, 900)
+    context.browser.set_window_size(2000, 1500)
     context.browser.implicitly_wait(30) # seconds
 
 ## Do this after completing everything.
@@ -112,7 +112,7 @@ def after_all(context):
 # gets smaller and hides the navbar search field.
 #
 def before_scenario(context, scenario):
-    context.browser.set_window_size(1100, 800)
+    context.browser.set_window_size(2000, 1500)
     time.sleep(1)
 
 def after_scenario(context, scenario):

--- a/tests/behave/maui_analyze.feature
+++ b/tests/behave/maui_analyze.feature
@@ -1,7 +1,7 @@
 
 Feature: Analyze phenotypes is usable by the expected user interfaces
  The tools behaves as expected given typical user input.
- 
+
  ## No Background necessary.
 
  @data
@@ -28,23 +28,21 @@ Feature: Analyze phenotypes is usable by the expected user interfaces
      when I submit analyze phenotype
      then the document should contain "pru1"
 
-## @data
-# Scenario: compare phenotype with geneList
-#    Given I go to page "/analyze/phenotypes"
-#     and I type "micro" into the phenotype analyze search
-#     and I wait until "Microalbuminuria" appears in the autocomplete
-#     and I click the autocomplete item "Microalbuminuria"
-#     and I click the "compare" radio button
-#     and I input "NCBIGene:388552,NCBIGene:3586" into the textarea "gene-list"
-#     when I submit analyze phenotype
-#     and I wait for id "phen_vis_svg_group"
-#     then the document should contain "IL10"
+@data
+ Scenario: compare phenotype with geneList
+    Given I go to page "/analyze/phenotypes"
+     and I type "micro" into the phenotype analyze search
+     and I wait until "Microalbuminuria" appears in the autocomplete
+     and I click the autocomplete item "Microalbuminuria"
+     and I click the "compare" radio button
+     and I input "NCBIGene:388552,NCBIGene:3586" into the textarea "gene-list"
+     when I submit analyze phenotype
+     and I wait for id "phen_vis_svg_group"
+     then the document should contain "IL10"
 
-     
-     
  ## Example how you might do other forms.
  # @data
- # Scenario: user uses a random form page with 
+ # Scenario: user uses a random form page with
  #    Given I go to page "/page-with-form"
  #     and I input the following text into the textarea "foo"
  #      """


### PR DESCRIPTION
- Improve `tests/behave/environment.py` to specific a web driver window size that is sufficiently large to let the virtual web browser _see_ the `phen_vis_svg_group` element, which is pretty far down the web page.
- Reenable the `tests/behave/maui_analyze.feature` unit test

I created an associated Issue to help folks find this problem easier in the future: https://github.com/monarch-initiative/monarch-app/issues/1291
