### PR TITLE
Reduces the amount of extraneous logging when invalid paths are specified.

### DIFF
--- a/lib/monarch/web/webapp.js
+++ b/lib/monarch/web/webapp.js
@@ -428,7 +428,7 @@ function buildEngine(defaultConfig, golrConfig) {
     },
     store: function(tbl, key, val) {
         var path = "./cache/"+tbl+"/key-"+key+".json";
-        console.log('###CACHE SAVE:', key);
+        // console.log('###CACHE SAVE:', key);
         env.fs_writeFileSync(path, JSON.stringify(val));
     },
     clear: function(match) {
@@ -952,6 +952,14 @@ web.wrapRouteGet(app, '/robots.txt', '/robots.txt', [],
     }, errorResponse
 );
 
+function wrapContentOrError(path) {
+    var result = web.wrapContent(path);
+    if (!result) {
+        result = errorResponse(404, 'Path not found: ' + path);
+    }
+
+    return result;
+}
 
 // anything in the docs/ directory is passed through statically
 
@@ -967,7 +975,8 @@ function docHandler(request, p1, p2, p3) {
         path += '/' + p3;
     }
 
-    return web.wrapContent(path);
+    var result = wrapContentOrError(path);
+    return result;
 }
 
 web.wrapRouteGet(app, '/docs/:p1/:p2/:p3', '/docs/{p1}/{p2}/{p3}', ['p1', 'p2', 'p3'], docHandler, errorResponse);
@@ -984,21 +993,21 @@ web.wrapRouteGet(app, '/fonts/:f', '/fonts/{f}', ['f'],
         else if (/^glyphicons/.test(f)) {
             path = './node_modules/bootstrap/dist/fonts/'+f;
         }
-        return web.wrapContent(path);
+        return wrapContentOrError(path);
     }, errorResponse
 );
 
 web.wrapRouteGet(app, '/image/:page', '/image/{page}', ['page'],
     function(request, page) {
         var path = './image/'+page;
-        return web.wrapContent(path);
+        return wrapContentOrError(path);
     }, errorResponse
 );
 
 web.wrapRouteGet(app, '/image/team/:page', '/image/team/{page}', ['page'],
     function(request, page) {
         var path = './image/team/'+page;
-        return web.wrapContent(path);
+        return wrapContentOrError(path);
     }, errorResponse
 );
 
@@ -1006,7 +1015,7 @@ web.wrapRouteGet(app, '/images/:file.png', '/images/{file}.png', ['file'],
     function(request, file) {
         var path = './node_modules/jquery-ui/themes/base/images/'+file + '.png';
         // console.log('resolving jqueryui base theme image:', path);
-        return web.wrapContent(path);
+        return wrapContentOrError(path);
     }, errorResponse
 );
 
@@ -1026,7 +1035,7 @@ web.wrapRouteGet(app, '/node_modules/phenogrid/:filename', '/node_modules/phenog
             //
             path = './node_modules/gfm.css/gfm.css';
         }
-        return web.wrapContent(path);
+        return wrapContentOrError(path);
     }, errorResponse
 );
 
@@ -1164,7 +1173,7 @@ if (useBundle && !useWebpack) {
         function(request, file, type) {
             var path = './dist/' + file + '.' + type;
             // console.log('resolving file.:type:', path);
-            return web.wrapContent(path);
+            return wrapContentOrError(path);
         }, errorResponse
     );
 }
@@ -1173,25 +1182,17 @@ if (useBundle && !useWebpack) {
     web.wrapRouteGet(app, '/app.bundle.js', '/app.bundle.js', [],
         function(request) {
             var path = './dist/app.bundle.js';
-            return web.wrapContent(path);
+            return wrapContentOrError(path);
         }, errorResponse
     );
 
     web.wrapRouteGet(app, '/app.bundle.css', '/app.bundle.css', [],
         function(request) {
             var path = './dist/app.bundle.css';
-            return web.wrapContent(path);
+            return wrapContentOrError(path);
         }, errorResponse
     );
 }
-
-web.wrapRouteGet(app, '/favicon.ico', '/favicon.ico', [],
-    function(request) {
-        var path = './image/favicon.ico';
-        // console.log('resolving favicon.ico');
-            return web.wrapContent(path);
-    }, errorResponse
-);
 
 
 // Method: autocomplete
@@ -4629,28 +4630,79 @@ if (false) { /* Disabling all /legacy/xxx and /labs/xxx endpoints that aren't du
  }
 
 
+function faviconHandler(request, fmt) {
+    var path = './image/favicon.ico';
+    return wrapContentOrError(path);
+}
+
+web.wrapRouteGet(app, '/favicon.ico', '/favicon.ico', [], faviconHandler, errorResponse);
+
 function resolveByIdHandler(request, id, fmt) {
-    var returnFunc;
+    var result;
 
     id = engine.convertIdToCurie(id);
 
     var type = engine.resolveIdToType(id);
     if (type) {
-        returnFunc = web.wrapRedirect(genURL(type, id));
+        result = web.wrapRedirect(genURL(type, id));
     } else {
-        engine.log(id);
-        returnFunc = notFoundResponse("Cannot find "+id);
+        // engine.log('Unable to resolve id: ' + id);
+        result = notFoundResponse('Unable to resolve id: ' + id);
     }
-    return returnFunc;
+
+    return result;
 }
+
+//
+// Same as the above resolveByIdHandler(), but only continues if the converted ID
+// looks like a CURIE. This is to avoid pinging SciGraph unnecessarily when a scraper
+// or client error tries to GET a path like /foo, which isn't intended to be an ID.
+//
+// This handler also deals with files like 'apple-touch-icon' by returning the favicon.ico
+// when requested. This is to avoid useless log messages in our server. See:
+//  http://stackoverflow.com/questions/5110776/apple-touch-icon-for-websites/21144916#21144916
+//
+// For the /resolve/ID endpoint handler (above), we can assume the user knows what they are doing and
+// can pass the purported ID through to SciGraph without checking. This will eventually
+// let us handle any cases where we want to have non-CURIE strings resolved via the /resolve
+// endpoint (although one could argue that would be a different endpoint).
+//
+
+function rootPathHandler(request, id, fmt) {
+    var result;
+
+    if (id.indexOf('apple-touch-icon') === 0) {
+        result = faviconHandler(request, id);
+    }
+    else {
+        id = engine.convertIdToCurie(id);
+
+        if (id.indexOf(':') === -1) {
+            result = notFoundResponse('No such path: ' + id);
+        }
+        else {
+            var type = engine.resolveIdToType(id);
+            if (type) {
+                result = web.wrapRedirect(genURL(type, id));
+            }
+            else {
+                // engine.log('Unable to resolve id: ' + id);
+                result = notFoundResponse('Unable to resolve id: ' + id);
+            }
+        }
+    }
+
+    return result;
+}
+
 
 // Order matters here in the declaration of these routes.
 web.wrapRouteGet(app, '/resolve/:id.:fmt?', '/resolve/{id}.{fmt}', ['id', 'fmt'], resolveByIdHandler, errorResponse);
 web.wrapRouteGet(app, '/resolve/:id', '/resolve/{id}', ['id'], resolveByIdHandler, errorResponse);
 
 // Duplicate the above for /{id}
-web.wrapRouteGet(app, '/:id.:fmt?', '/{id}.{fmt}', ['id', 'fmt'], resolveByIdHandler, errorResponse);
-web.wrapRouteGet(app, '/:id', '/{id}', ['id'], resolveByIdHandler, errorResponse);
+web.wrapRouteGet(app, '/:id.:fmt?', '/{id}.{fmt}', ['id', 'fmt'], rootPathHandler, errorResponse);
+web.wrapRouteGet(app, '/:id', '/{id}', ['id'], rootPathHandler, errorResponse);
 
 //Dowloads Section
 

--- a/lib/monarch/web/webenv.js
+++ b/lib/monarch/web/webenv.js
@@ -356,21 +356,29 @@ else {
 
     function wrapContent(filePath) {
         var fileInfo = getFileInfo(filePath);
-        var ctype = fileInfo.mimeType;
-        var output = 'Unknown encoding for: ' + filePath;
-        if (fileInfo.encoding === 'utf8') {
-          output = env.fs_readFileSync(filePath) + '';
-        }
-        else if (fileInfo.encoding === 'binary') {
-          output = env.fs_readFileSyncBinary(filePath);
-        }
+        var result;
 
-        // console.log('###wrapContent(', filePath, ') info:', fileInfo, ' output[', typeof output, '] length:', output.length);
-        var result = {
-                status: 200,
-                headers: {"Content-Type": ctype},
-                body: output
-            };
+        if (env.fs_existsSync(filePath)) {
+            var ctype = fileInfo.mimeType;
+            var output = 'Unknown encoding for: ' + filePath;
+            if (fileInfo.encoding === 'utf8') {
+              output = env.fs_readFileSync(filePath) + '';
+            }
+            else if (fileInfo.encoding === 'binary') {
+              output = env.fs_readFileSyncBinary(filePath);
+            }
+
+            // console.log('###wrapContent(', filePath, ') info:', fileInfo, ' output[', typeof output, '] length:', output.length);
+            result = {
+                        status: 200,
+                        headers: {"Content-Type": ctype},
+                        body: output
+                    };
+        }
+        else {
+            console.log('###wrapContent(', filePath, ') does not exist');
+            result = null;
+        }
         return result;
     }
 

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
   "scripts": {
     "analyze": "rm -rf dist/* && node_modules/webpack/bin/webpack.js --config webpack.build.js --bail --json | analyze-bundle-size",
     "build": "gulp build && rm -rf dist/* && node_modules/webpack/bin/webpack.js --config webpack.build.js --bail",
-    "start": "gulp build && NODE_PATH=lib/monarch node --harmony_destructuring lib/monarch/web/webapp_launcher.js",
-    "oldstart": "NODE_PATH=lib/monarch USE_BUNDLE=0 node --harmony_destructuring lib/monarch/web/webapp_launcher.js",
+    "start": "npm run build && NODE_PATH=lib/monarch node --harmony_destructuring lib/monarch/web/webapp_launcher.js",
     "dev": "gulp build && scripts/runWebpackDevServer.sh",
     "devp": "gulp build && USE_PUPTENT_NOCACHE=1 scripts/runWebpackDevServer.sh production",
     "corstest": "USE_LOG_FETCH=1 USE_WEBPACK=1 NODE_PATH=lib/monarch nodemon -d 2 -V --harmony_destructuring -- lib/monarch/web/webapp_launcher.js CORSTest & node node_modules/.bin/webpack-dev-server --port 8081",


### PR DESCRIPTION
This is mostly in response to https://github.com/monarch-initiative/monarch-app/issues/1239
- Reduces the amount of extraneous logging when invalid paths are specified. For example, /apple-touch-icon-precomposed or /docs/foo. In most cases, these invalid paths were due to bots or cached older versions of the webapp, or due to Apple-specific browser behavior (cf http://stackoverflow.com/questions/5110776/apple-touch-icon-for-websites/21144916#21144916).
- Eliminates a round-trip to SciGraph when an invalid path is specified. For example, /foo used to ping SciGraph, just in case foo is an id.
- Ensures that the webenv.wrapContent() method checks for file existence prior to trying to read it. This eliminates an annoying stack crawl in the log files.
- Fixes the package.json 'run start' script so that it uses 'npm run build' rather than just 'gulp build'.
