### PR TITLE
switch prefix for owlsim OMIM -> MONDO

### DIFF
--- a/lib/monarch/api.js
+++ b/lib/monarch/api.js
@@ -990,7 +990,7 @@ bbop.monarch.Engine.prototype.searchByPhenotypeProfile = function(query,target_s
     // TODO - nif sources are no longer used
     var species_to_filter_map = {
             '10090' : { label : 'Mus musculus', target_idspace : 'MGI', b_type : 'gene', b_source : 'nif-0000-00096-6' },
-            '9606' : { label : 'Homo sapiens', target_idspace : 'OMIM', b_type : 'disease',b_source : 'nlx_151835-1'},
+            '9606' : { label : 'Homo sapiens', target_idspace : 'MONDO', b_type : 'disease',b_source : 'nlx_151835-1'},
             '7227' : { label : 'Drosophila melanogaster', target_idspace : 'FlyBase', b_type : 'gene',b_source : 'nif-0000-00558-2'},
             '6239' : { label : 'C elegans', target_idspace : 'WormBase', b_type : 'gene',b_source : 'nif-0000-00558-2'},
             '7955' : { label : 'Danio rerio', target_idspace : 'ZFIN', b_type : 'gene', b_source : 'nif-0000-21427-10'},
@@ -1510,7 +1510,7 @@ bbop.monarch.Engine.prototype.searchByAttributeSet = function(atts, tf, limit) {
                     ph.target = 'MGI';
                 }
                 else if (tf.species == 9606) {
-                    ph.target = 'OMIM';
+                    ph.target = 'MONDO';
                 }
                 else if (tf.species == 7955) {
                     ph.target = 'ZFIN';


### PR DESCRIPTION
Since owlsim2 filters are based on id prefix, we need to switch from OMIM to MONDO to support the new release.  Note there are 24 OMIM diseases without a mondo equivalent, that would be filtered out of the phenogrid view.