### PR TITLE
Production Uglify/Babel fixes. Fix search_results to not crash with bad data.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
-  "presets": ["es2015"],
-  "plugins": ["syntax-dynamic-import"]
+  "presets": ["env"],
+  "plugins": ["transform-runtime", "syntax-dynamic-import"]
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,7 @@ before_install:
 install:
   - "rm -rf node_modules/"
   - "./install.sh"
+  - "NODE_ENV=production npm run wbs-webpack-build-prod"
   - "ls -lhS dist/"
   - "sudo pip install selenium"
   - "sudo pip install --upgrade selenium"

--- a/install.sh
+++ b/install.sh
@@ -12,4 +12,4 @@ npm install
 ./node_modules/.bin/webpack -p --config=utils/bbop-webpack.config.js
 ./node_modules/.bin/webpack -p --config=utils/phenogrid-webpack.config.js
 
-NODE_ENV=production npm run wbs-webpack-build-prod
+# NODE_ENV=production npm run wbs-webpack-build-prod

--- a/package.json
+++ b/package.json
@@ -58,8 +58,8 @@
     "babel-eslint": "^8.2.2",
     "babel-loader": "^7.1.4",
     "babel-plugin-syntax-dynamic-import": "^6.18.0",
-    "babel-preset-es2015": "^6.24.1",
-    "babel-preset-stage-2": "^6.24.1",
+    "babel-plugin-transform-runtime": "^6.23.0",
+    "babel-preset-env": "^1.6.1",
     "browser-sync-webpack-plugin": "^2.2.2",
     "chai": "^4.1.2",
     "css-loader": "^0.28.11",
@@ -137,7 +137,6 @@
     "underscore": "^1.8.3",
     "vue": "^2.5.16",
     "vue-good-table": "^1.19.2",
-    "vue-json-tree": "^0.3.3",
     "vue-router": "^3.0.1",
     "wait.for": "^0.6.6",
     "xml2js": "^0.4.19"

--- a/templates/search_results.mustache
+++ b/templates/search_results.mustache
@@ -33,10 +33,19 @@
                   <thead><tr><th width="25%">Term</th><th width="15%">Category</th><th width="25%">Taxon</th><th>Matching String</th></tr></thead>
                   <tbody>
                     <tr class="search-result-item" v-for="(result, index) in results">
-                      <td><a data-monarch-legacy v-bind:href="'/' + result.category_std[0].toLowerCase() + '/' + result.id" v-html="result.label[0]"></a></td>
-                      <td v-html="result.category.join(',')"></td>
-                      <td v-html="typeof result.taxon_label === 'object' ? result.taxon_label.join(',') : result.taxon_label"></td>
-                      <td v-html="highlight[result.id]"></td>
+                      <td
+                        v-if="result.linkURL">
+                        <a data-monarch-legacy
+                          v-bind:href="result.linkURL"
+                          v-html="result.linkName"></a>
+                      </td>
+                      <td
+                        v-else
+                        v-html="result.linkName">
+                      </td>
+                      <td>{[{result.categoryCommas}]}</td>
+                      <td>{[{result.taxonLabel}]}</td>
+                      <td v-html="result.htmlHighlight"></td>
                     </tr>
                   </tbody>
                 </table>

--- a/ui/components/Node.vue
+++ b/ui/components/Node.vue
@@ -229,20 +229,6 @@
               :identifier="nodeId">
       </table-view>
     </div>
-
-<!--
-    <br>
-    <br>
-    <br>
-    <br>
-
-    <div class="row pre-scrollable">
-      <div class="col-xs-12">
-        <json-tree :data="node" :level="1"></json-tree>
-      </div>
-    </div>
- -->
-
   </div>
 </div>
 

--- a/ui/index.ejs
+++ b/ui/index.ejs
@@ -13,9 +13,6 @@
     <link
       href="<%= webpackConfig.output.publicPath + (Object.prototype.toString.call(webpack.assetsByChunkName['app']) === '[object Array]' ? webpack.assetsByChunkName['app'][1] : webpack.assetsByChunkName['app']) %>"
       rel="stylesheet">
-    <link
-      href="<%= webpackConfig.output.publicPath + (Object.prototype.toString.call(webpack.assetsByChunkName['spa']) === '[object Array]' ? webpack.assetsByChunkName['spa'][1] : webpack.assetsByChunkName['spa']) %>"
-      rel="stylesheet">
     <% } %>
 
     <style>
@@ -70,8 +67,6 @@ function loaderBody() {
   <% if (!htmlWebpackPlugin.options.MODE_DEV_SERVER) { %>
     <script
       src="<%= webpackConfig.output.publicPath + (Object.prototype.toString.call(webpack.assetsByChunkName['app']) === '[object Array]' ? webpack.assetsByChunkName['app'][0] : webpack.assetsByChunkName['app']) %>"></script>
-    <script
-      src="<%= webpackConfig.output.publicPath + (Object.prototype.toString.call(webpack.assetsByChunkName['spa']) === '[object Array]' ? webpack.assetsByChunkName['spa'][0] : webpack.assetsByChunkName['spa']) %>"></script>
   <% } %>
 
       <!-- Google Analytics

--- a/ui/main.js
+++ b/ui/main.js
@@ -7,7 +7,6 @@ import Router from 'vue-router';
 import VueGoodTable from 'vue-good-table';
 import BootstrapVue from 'bootstrap-vue/dist/bootstrap-vue.esm';
 import 'bootstrap-vue/dist/bootstrap-vue.css';
-import JsonTree from 'vue-json-tree';
 import App from './App.vue';
 import Home from '@/components/Home.vue';
 import Navbar from '@/components/Navbar.vue';
@@ -18,10 +17,6 @@ import TableView from '@/components/TableView.vue';
 import AssocFacets from '@/components/AssocFacets.vue';
 import MonarchAutocomplete from '@/components/MonarchAutocomplete.vue';
 import ExacGeneSummary from '@/components/ExacGeneSummary.vue';
-
-
-
-Vue.component('json-tree', JsonTree);
 
 
 /**

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -230,8 +230,7 @@ const config = {
         test: /\.vue$/,
         loader: 'vue-loader',
         include: [
-          path.resolve('ui'),
-          path.resolve('node_modules/vue-json-tree/src/')
+          path.resolve('ui')
         ],
         options: {
           esModule: true,
@@ -262,7 +261,11 @@ const config = {
           path.resolve('js'),
           path.resolve('node_modules/q'),
           path.resolve('node_modules/webpack-dev-server/client')],
-        loader: 'babel-loader'
+        loader: 'babel-loader',
+        // options: {
+        //   presets: [path.resolve('node_modules/babel-preset-env')],
+        //   plugins: ["fast-async", "syntax-dynamic-import"]
+        // }
       },
       {
         test: /\.css$/,


### PR DESCRIPTION
- Fixes webpack config so that a production build of NG works properly  …
with Babel and async/await.
- Improves robustness of search_results (Legacy and NG), mostly to work
  around the beta data issues with multiple categories, but also to move
more logic into JS from the HTML template.
- Eliminates use of vue-json-tree, which was there for debugging in the
  early days of MonarchNG.
- Updates babel to use babel-preset-env
- Moves the production build step from install.sh into .travis.yml, so
  that install.sh doesn't take as long and perform an unnecessary build
for ordinary development.
- Remove reference to the spa.bundle.js and spa.bundle.css that are no longer being generated or used