### PR TITLE
NodeSidebar.vue, full-width home footer, SCSS

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -18,7 +18,8 @@
     "spaced-comment": 1,
     "quotes": ["error", "single", { "allowTemplateLiterals": true }],
     "import/prefer-default-export": "off",
-    "arrow-parens": ["error", "as-needed"]
+    "arrow-parens": ["error", "as-needed"],
+    "vue/html-self-closing": 0
   },
   "extends": [
     "plugin:vue/strongly-recommended",

--- a/css/_prelude-ng.scss
+++ b/css/_prelude-ng.scss
@@ -7,3 +7,12 @@ $grid-float-breakpoint: 700px;
 
 $link-color: #0088ce;
 
+$monarch-bg-color: #15556A;
+
+$grid-breakpoints: (
+  xs: 0,
+  sm: 576px,
+  md: 768px,
+  lg: 950px, // Original BS4 value: 992px
+  xl: 1200px
+) !default;

--- a/js/MonarchAccess/index.js
+++ b/js/MonarchAccess/index.js
@@ -25,7 +25,7 @@ export function getNodeSummary(nodeId, nodeType) {
   const returnedPromise = new Promise((resolve, reject) => {
     axios.get(url)
       .then(resp => {
-        const responseData = resp.data
+        const responseData = resp.data;
         // const { responseURL } = resp.request;
         // console.log('...getNodeSummary', resp, responseData, responseURL);
         if (typeof responseData !== 'object') {

--- a/ui/.eslintrc
+++ b/ui/.eslintrc
@@ -18,7 +18,11 @@
     "spaced-comment": 1,
     "quotes": ["error", "single", { "allowTemplateLiterals": true }],
     "import/prefer-default-export": "off",
-    "arrow-parens": ["error", "as-needed"]
+    "arrow-parens": ["error", "as-needed"],
+    "vue/html-self-closing": 0,
+    "vue/html-indent": 1,
+    "global-require": 0,
+    "no-unused-vars": [0, { "argsIgnorePattern": "^_" }],
   },
   "extends": [
     "plugin:vue/strongly-recommended",

--- a/ui/components/AssocFacets.vue
+++ b/ui/components/AssocFacets.vue
@@ -1,7 +1,9 @@
 <template>
   <div
     class="assoc-facets-wrapper">
-    <div v-for="(value, key) in facetObject">
+    <div
+      v-for="(value, key) in facetObject"
+      :key="key">
       <label>
         <input
           type="checkbox"
@@ -13,24 +15,31 @@
   </div>
 </template>
 <script>
-  export default {
-    model: {
-      prop: 'facetObject'
-    },
-    props: {
-      facetObject: {
-        type: Object,
-      }
-    },
-  };
+export default {
+  model: {
+    prop: 'facetObject'
+  },
+
+  /* eslint vue/require-default-prop: 0 */
+  props: {
+    facetObject: {
+      type: Object,
+    }
+  },
+};
 </script>
-<style scoped>
+<style lang="scss">
 .assoc-facets-wrapper {
-  height: 200px;
-  overflow-y: scroll;
+  margin: 0;
+  padding: 0;
   padding: 0;
   margin: 0;
+  background: #444;
+
+  label {
+    margin: 0;
+    padding-left: 4px;
+  }
 }
 </style>
-
 

--- a/ui/components/AssocTable.vue
+++ b/ui/components/AssocTable.vue
@@ -373,12 +373,19 @@
             biolinkAnnotationSuffix,
             params
           );
+          // console.log('searchResponse');
+          // console.log(JSON.stringify(searchResponse, null, 2));
+          if (!searchResponse.data ||
+              !searchResponse.data.associations) {
+            that.dataPacket = null;
+            throw new Error('MA.getNodeAssociations() returned no data');
+          }
           that.dataPacket = searchResponse;
           that.dataFetched = true;
         }
         catch (e) {
           that.dataError = e;
-          console.log('BioLink Error', e);
+          // console.log('BioLink Error', e);
         }
 
       },
@@ -539,7 +546,9 @@
         this.fetchData();
       },
       dataPacket() {
-        this.populateRows();
+        if (this.dataPacket) {
+          this.populateRows();
+        }
       },
       facets: {
         handler() {
@@ -551,7 +560,7 @@
     },
   };
 </script>
-<style>
+<style scoped>
   a {
     color: #404040;
   }

--- a/ui/components/ExacGeneSummary.vue
+++ b/ui/components/ExacGeneSummary.vue
@@ -47,7 +47,7 @@
   import axios from 'axios';
   export default {
     props: {
-      nodeID: {
+      nodeId: {
         type: String,
         required: true,
       },
@@ -71,7 +71,7 @@
     },
     computed: {
       nodePrefix() {
-        const splitID = this.nodeID.split(':');
+        const splitID = this.nodeId.split(':');
         return {
           prefix: splitID[0],
           identifier: splitID[1],

--- a/ui/components/ExacVariantTable.vue
+++ b/ui/components/ExacVariantTable.vue
@@ -86,7 +86,7 @@
   import axios from 'axios';
   export default {
     props: {
-      nodeID: {
+      nodeId: {
         type: String,
         required: true,
       },
@@ -109,10 +109,10 @@
     },
     computed: {
       nodePrefix() {
-        const splitID = this.nodeID.split(':');
+        const splitId = this.nodeId.split(':');
         return {
-          prefix: splitID[0],
-          identifier: splitID[1],
+          prefix: splitId[0],
+          identifier: splitId[1],
         }
       },
     },

--- a/ui/components/Home.vue
+++ b/ui/components/Home.vue
@@ -1,8 +1,8 @@
 <template>
 <div id="selenium_id_content">
-  <div
-    id="monarch-home-container"
-    class="container-fluid monarch-container">
+<div
+  id="monarch-home-container"
+  class="container-fluid monarch-container">
 
   <header class="intro">
     <div class="intro-body">
@@ -22,57 +22,12 @@
             </p>
             <monarch-autocomplete homeSearch="true">
             </monarch-autocomplete>
-            <!--<p class="search-examples-text">-->
-              <!--Examples: <i>Marfan Syndrome</i> <i>sox3</i>-->
-            <!--</p>-->
-
-            <!--a href="#footer-fake" class="btn btn-circle page-scroll">
-              <i class="fa fa-angle-double-down animated"></i>
-            </a-->
 
           </div>
         </div>
       </div>
     </div>
   </header>
-
-<!--
-  <section>
-    id="search"
-    class="container search-section text-center">
-    <div class="container">
-
-      <div class="row">
-        <div class="col-xs-12">
-
-          <form
-            id="home_search_form"
-            class="searchspace"
-            action="/search"
-            role="search">
-            <div class="input-group">
-              <span class="input-group-addon" id="sizing-addon1">
-              <i class="fa fa-search fa-fw"></i>
-              </span>
-              <input
-                autofocus
-                id="home_search" type="text" class="form-control" placeholder="Search for...">
-
-              <span class="input-group-btn">
-              <button class="btn btn-default" type="button">Search</button>
-              </span>
-
-
-            </div>
-          </form>
-
-        </div>
-      </div>
-
-    </div>
-  </section>
- -->
-
 
   <section id="about" class="container content-section text-center">
     <div class="row">
@@ -119,7 +74,7 @@
               </a>
             </li>
             <li>
-              <a href="https://medium.com/@MonarchInit/exomiser-10-faster-leaner-better-c988650488be"> 
+              <a href="https://medium.com/@MonarchInit/exomiser-10-faster-leaner-better-c988650488be">
               March 22, 2018: <b>Exomiser 10: Faster, Leaner, Better</b>
               </a>
             </li>
@@ -133,7 +88,7 @@
           <h3>Upcoming Events</h3>
           <ul class="list-inline">
             <li>
-              <a href="http://icbo2018.cgrb.oregonstate.edu/"> 
+              <a href="http://icbo2018.cgrb.oregonstate.edu/">
               ICBO Conference, Aug 7, 2018
               </a>
             </li>
@@ -163,15 +118,15 @@
     <div class="container">
     <div class="row">
       <div class="col-sm">
-        <i class="fa fa-child fa-fw" style="color: #15556A; font-size: 2em;"></i> 
+        <i class="fa fa-child fa-fw" style="color: #15556A; font-size: 2em;"></i>
         <span class="network-name"><br><b>218,313</b><br>Disease-Phenotype Associations</span>
       </div>
       <div class="col-sm">
-        <i class="fa fa-tint fa-fw" style="color: #15556A; font-size: 2em;"></i> 
+        <i class="fa fa-tint fa-fw" style="color: #15556A; font-size: 2em;"></i>
         <span class="network-name"><br><b>793,526</b><br>Gene-Phenotype Associations</span>
       </div>
       <div class="col-sm">
-        <i class="fa fa-paw fa-fw" style="color: #15556A; font-size: 2em;"></i> 
+        <i class="fa fa-paw fa-fw" style="color: #15556A; font-size: 2em;"></i>
         <span class="network-name"><br><b>20,870</b><br>Model Associations</span>
       </div>
     </div>
@@ -179,102 +134,109 @@
   </section>
 
   <section class="content-section text-center">
-      <h4 class="text-center" style="margin: 10px; padding: 0px 0px 25px 0px;"> The Monarch Initiative is a collaboration between: </h4>
-      <div class="container">
-        <div class="row">
-          <div class="col-6 col-md-3">
-            <div class="media">
-              <a target="_blank" href="https://www.charite.de/en/"><span class="network-name"></span>
-              <img class="mr-3"
-              style="max-height:35px;"
-              src="../assets/images/team-charite.png"
-              alt="Charite">
-              </a>
-            </div>
+    <h4
+      class="text-center"
+      style="margin: 10px; padding: 0px 0px 25px 0px;">
+      The Monarch Initiative is a collaboration between:
+    </h4>
+    <div class="container">
+      <div class="row">
+        <div class="col-6 col-md-3">
+          <div class="media">
+            <a target="_blank" href="https://www.charite.de/en/"><span class="network-name"></span>
+            <img class="mr-3"
+            style="max-height:35px;"
+            src="../assets/images/team-charite.png"
+            alt="Charite">
+            </a>
           </div>
-          <div class="col-6 col-md-3">  
-            <div class="media">
-              <a target="_blank" href="https://www.garvan.org.au/"><span class="network-name"></span>
-              <img class="mr-3"
-              style="max-height:35px;"
-              src="../assets/images/team-garvan.png"
-              alt="Garvan">
-              </a>
-            </div>
+        </div>
+        <div class="col-6 col-md-3">
+          <div class="media">
+            <a target="_blank" href="https://www.garvan.org.au/"><span class="network-name"></span>
+            <img class="mr-3"
+            style="max-height:35px;"
+            src="../assets/images/team-garvan.png"
+            alt="Garvan">
+            </a>
           </div>
-          <div class="col-6 col-md-3">
-            <div class="media">
-              <a target="_blank" href="https://www.jax.org/"><span class="network-name"></span>
-              <img class="mr-3"
-              style="max-height:35px;"
-              src="../assets/images/team-jackson.png"
-              alt="Jax">
-              </a>
-            </div>
+        </div>
+        <div class="col-6 col-md-3">
+          <div class="media">
+            <a target="_blank" href="https://www.jax.org/"><span class="network-name"></span>
+            <img class="mr-3"
+            style="max-height:35px;"
+            src="../assets/images/team-jackson.png"
+            alt="Jax">
+            </a>
           </div>
-          <div class="col-6 col-md-3">
-            <div class="media">
-              <a target="_blank" href="http://www.lbl.gov/"><span class="network-name"></span>
-              <img class="mr-3"
-              style="max-height:25px;"
-              src="../assets/images/team-lbnl.jpeg"
-              alt="LBNL">
-              </a>
-            </div>
+        </div>
+        <div class="col-6 col-md-3">
+          <div class="media">
+            <a target="_blank" href="http://www.lbl.gov/"><span class="network-name"></span>
+            <img class="mr-3"
+            style="max-height:25px;"
+            src="../assets/images/team-lbnl.jpeg"
+            alt="LBNL">
+            </a>
           </div>
-          <div class="col-6 col-md-3">
-            <div class="media">
-              <a target="_blank" href="https://www.ohsu.edu/"><span class="network-name"></span>
-              <img class="mr-3"
-              style="max-height:35px;"
-              src="../assets/images/team-ohsu.gif"
-              alt="OHSU">
-              </a>
-            </div>
+        </div>
+        <div class="col-6 col-md-3">
+          <div class="media">
+            <a target="_blank" href="https://www.ohsu.edu/"><span class="network-name"></span>
+            <img class="mr-3"
+            style="max-height:35px;"
+            src="../assets/images/team-ohsu.gif"
+            alt="OHSU">
+            </a>
           </div>
-          <div class="col-6 col-md-3">
-            <div class="media">
-              <a target="_blank" href="http://www.smd.qmul.ac.uk/"><span class="network-name"></span>
-              <img class="mr-3"
-              style="max-height:35px;"
-              src="../assets/images/team-qmul.png"
-              alt="QMUL">
-              </a>
-            </div>
+        </div>
+        <div class="col-6 col-md-3">
+          <div class="media">
+            <a target="_blank" href="http://www.smd.qmul.ac.uk/"><span class="network-name"></span>
+            <img class="mr-3"
+            style="max-height:35px;"
+            src="../assets/images/team-qmul.png"
+            alt="QMUL">
+            </a>
           </div>
-          <div class="col-6 col-md-3">
-            <div class="media">
-              <a target="_blank" href="http://renci.org/"><span class="network-name"></span>
-              <img class="mr-3"
-              style="max-height:35px;"
-              src="../assets/images/team-renci.png"
-              alt="RENCI">
-              </a>
-            </div>
+        </div>
+        <div class="col-6 col-md-3">
+          <div class="media">
+            <a target="_blank" href="http://renci.org/"><span class="network-name"></span>
+            <img class="mr-3"
+            style="max-height:35px;"
+            src="../assets/images/team-renci.png"
+            alt="RENCI">
+            </a>
           </div>
-          <div class="col-6 col-md-3">
-            <div class="media">
-              <a target="_blank" href="http://www.sanger.ac.uk/"><span class="network-name"></span>
-              <img class="mr-3"
-              style="max-height:35px;"
-              src="../assets/images/team-sanger.png"
-              alt="Sanger">
-              </a>
-            </div>
+        </div>
+        <div class="col-6 col-md-3">
+          <div class="media">
+            <a target="_blank" href="http://www.sanger.ac.uk/"><span class="network-name"></span>
+            <img class="mr-3"
+            style="max-height:35px;"
+            src="../assets/images/team-sanger.png"
+            alt="Sanger">
+            </a>
           </div>
+        </div>
       </div>
-      <div style="padding: 25px 15px 0px 15px;">
-        Monarch is supported generously by a NIH Office of the Director Grant #5R24OD011883,
-        as well as by NIH-UDP: HHSN268201350036C, HHSN268201400093P, NCI/Leidos #15X143.
-        We are grateful to the many <a target="_blank" href="/about/sources">original sources of our data</a> for allowing Monarch to integrate them in this way.
-        Except where forbidden by the original sources, this work is licensed under a
-        Creative Commons Attribution 3.0 License.
-      </div>
+    </div>
+    <div style="padding: 25px 15px 0px 15px;">
+      Monarch is supported generously by a NIH Office of the Director Grant #5R24OD011883,
+      as well as by NIH-UDP: HHSN268201350036C, HHSN268201400093P, NCI/Leidos #15X143.
+      We are grateful to the many <a target="_blank" href="/about/sources">original sources of our data</a> for allowing Monarch to integrate them in this way.
+      Except where forbidden by the original sources, this work is licensed under a
+      Creative Commons Attribution 3.0 License.
     </div>
   </section>
 
-  <home-footer>
-  </home-footer>
+  <footer class="footer">
+    <home-footer>
+    </home-footer>
+  </footer>
+
 </div>
 </div>
 </template>
@@ -332,273 +294,149 @@ export default {
 </script>
 
 
+<style lang="scss">
+  @import "../../css/_prelude-ng.scss";
+  $home-primary: pink;  // #42DCA3;
 
-<style>
-$home-primary: #42DCA3;
 
-
-body {
-  width: 100%;
-  height: 100%;
-  font-family: "Lora","Helvetica Neue",Helvetica,Arial,sans-serif;
-  color: white;
-  background-color: black;
-}
-
-html {
-  width: 100%;
-  height: 100%;
-}
-
-#monarch-home-container h1,
-#monarch-home-container h2,
-#monarch-home-container h3,
-*/ COMMENT OUT #monarch-home-container h4, */
-#monarch-home-container h5,
-#monarch-home-container h6 {
-  margin: 0 0 35px;
-  text-transform: uppercase;
-  font-family: "Montserrat","Helvetica Neue",Helvetica,Arial,sans-serif;
-  font-weight: 700;
-  letter-spacing: 1px;
-}
-
-#monarch-home-container p {
-  margin: 0 0 25px;
-  font-size: 18px;
-  line-height: 1.5;
-  @media(min-width:768px) {
-    margin: 0 0 35px;
-    font-size: 20px;
-    line-height: 1.6;
+  #monarch-home-container h1,
+  #monarch-home-container h2,
+  #monarch-home-container h3,
+  #monarch-home-container h4,
+  #monarch-home-container h5,
+  #monarch-home-container h6 {
+    xmargin: 0 0 35px 0;
+    xtext-transform: uppercase;
+    xfont-family: "Montserrat","Helvetica Neue",Helvetica,Arial,sans-serif;
+    xfont-weight: 700;
+    xletter-spacing: 1px;
   }
-}
 
-#monarch-home-container a {
-  color: $home-primary;
-  -webkit-transition: all .2s ease-in-out;
-  -moz-transition: all .2s ease-in-out;
-  transition: all .2s ease-in-out;
-  &:hover,
-  &:focus {
-    text-decoration: none;
-    color: darken($home-primary,20%);
-  }
-}
-
-#monarch-home-container .light {
-  font-weight: 400;
-}
-
-#monarch-home-container .intro .search-examples-text {
-  background: lightgray;
-  color: black;
-  border:1px solid lightgray;
-  font-size: 0.9em;
-}
-
-#monarch-home-container .intro {
-  display: table;
-  width: 100%;
-  height: auto;
-  padding: 50px 0;
-  text-align: center;
-  color: white;
-  xbackground: url(../assets/images/home-splash.png) no-repeat bottom center scroll;
-  background-color: #15556A;
-  */ -webkit-background-size: cover;*/
-  */ -moz-background-size: cover;*/
-  */ background-size: cover;*/
-  */ -o-background-size: cover;*/
-  .intro-body {
-    display: table-cell;
-    vertical-align: middle;
-    .brand-heading {
-      font-size: 40px;
-    }
-    .intro-text {
-      font-size: 18px;
+  #monarch-home-container p {
+    margin: 0 0 25px;
+    font-size: 18px;
+    line-height: 1.5;
+    @media(min-width:$grid-float-breakpoint) {
+      margin: 0 0 35px;
+      font-size: 20px;
+      line-height: 1.6;
     }
   }
-  @media(min-width:768px) {
-    height: 100%;
-    padding: 0;
+
+
+  // #monarch-home-container a {
+  //   color: $link-color;
+  //   -webkit-transition: all .2s ease-in-out;
+  //   -moz-transition: all .2s ease-in-out;
+  //   transition: all .2s ease-in-out;
+  //   &:hover,
+  //   &:focus {
+  //     xtext-decoration: none;
+  //     color: darken($link-color,20%);
+  //   }
+  // }
+
+  #monarch-home-container .light {
+    font-weight: 400;
+  }
+
+  #monarch-home-container header.intro {
+    display: table;
+    width: 100%;
+    height: auto;
+    padding: 50px 0;
+    text-align: center;
+    color: white;
+    background-color: $monarch-bg-color;
+
     .intro-body {
+      display: table-cell;
+      vertical-align: middle;
+
       .brand-heading {
-        font-size: 100px;
+        padding: 20px 0 20px 0;
       }
       .intro-text {
-        font-size: 26px;
+        font-size: 18px;
       }
     }
-  }
-}
 
-#monarch-home-container .btn-circle {
-  width: 70px;
-  height: 70px;
-  margin-top: 15px;
-  padding: 7px 16px;
-  border: 2px solid white;
-  border-radius: 100% !important;
-  font-size: 40px;
-  color: white;
-  background: transparent;
-  -webkit-transition: background .3s ease-in-out;
-  -moz-transition: background .3s ease-in-out;
-  transition: background .3s ease-in-out;
-  &:hover,
-  &:focus {
-    outline: none;
-    color: white;
-    background: rgba(white, 0.1);
-  }
-  i.animated {
-    -webkit-transition-property: -webkit-transform;
-    -webkit-transition-duration: 1s;
-    -moz-transition-property: -moz-transform;
-    -moz-transition-duration: 1s;
-  }
-  &:hover {
-    i.animated {
-      -webkit-animation-name: pulse;
-      -moz-animation-name: pulse;
-      -webkit-animation-duration: 1.5s;
-      -moz-animation-duration: 1.5s;
-      -webkit-animation-iteration-count: infinite;
-      -moz-animation-iteration-count: infinite;
-      -webkit-animation-timing-function: linear;
-      -moz-animation-timing-function: linear;
+    @media(min-width:$grid-float-breakpoint) {
+      .intro-body {
+        .intro-text {
+          font-size: 26px;
+        }
+      }
+
     }
   }
-}
 
-@-webkit-keyframes pulse {
-  from {
-    -webkit-transform: scale(1);
-    transform: scale(1);
+  #monarch-home-container .content-section {
+    padding-top: 50px;
+    padding-bottom: 50px;
+    font-size: 18px;
   }
 
-  50% {
-    -webkit-transform: scale(1.2);
-    transform: scale(1.2);
+  #monarch-home-container .data-dashboard {
+    padding-top: 50px;
+    padding-bottom: 50px;
+    font-size: 18px;
+    background: #EBEBEB;
   }
 
-  100% {
-    -webkit-transform: scale(1);
-    transform: scale(1);
-  }
-}
-
-@-moz-keyframes pulse {
-  from {
-    -moz-transform: scale(1);
-    transform: scale(1);
+  #monarch-home-container .news-section {
+    padding-top: 50px;
+    padding-bottom: 50px;
+    font-size: 18px;
   }
 
-  50% {
-    -moz-transform: scale(1.2);
-    transform: scale(1.2);
+  #monarch-home-container .search-section {
+    padding: 50px 10px;
   }
 
-  100% {
-    -moz-transform: scale(1);
-    transform: scale(1);
-  }
-}
 
-#monarch-home-container .content-section {
-  padding-top: 50px;
-  padding-bottom: 50px;
-  font-size: 18px;
-}
-
-#monarch-home-container .data-dashboard {
-  padding-top: 50px;
-  padding-bottom: 50px;
-  font-size: 18px;
-  background: #EBEBEB;
-}
-
-#monarch-home-container .news-section {
-  padding-top: 50px;
-  padding-bottom: 50px;
-  font-size: 18px;
-}
-
-#monarch-home-container .search-section {
-  padding: 50px 10px;
-}
-
-
-#monarch-home-container .features-section {
-  height: auto;
-  width: 100%;
-  padding: 50px 0;
-  color: black;
-  font-size: 18px;
-  background-color: #E8E8E8;
-  -webkit-background-size: cover;
-  -moz-background-size: cover;
-  background-size: cover;
-  -o-background-size: cover;
-}
-
-
-#monarch-home-container .partners-section {
-  padding: 50px 10px;
-}
-
-
-@media(min-width:767px) {
-}
-
-#monarch-home-container .btn {
-  text-transform: uppercase;
-  font-family: "Montserrat","Helvetica Neue",Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  -webkit-transition: all .3s ease-in-out;
-  -moz-transition: all .3s ease-in-out;
-  transition: all .3s ease-in-out;
-  /*border-radius: 0;*/
-}
-
-#monarch-home-container .btn-default {
-  border: 1px solid $home-primary;
-  color: $home-primary;
-  background-color: transparent;
-  &:hover,
-  &:focus {
-    border: 1px solid $home-primary;
-    outline: none;
+  #monarch-home-container .features-section {
+    height: auto;
+    width: 100%;
+    padding: 50px 0;
     color: black;
-    background-color: $home-primary;
+    font-size: 18px;
+    background-color: #E8E8E8;
+    -webkit-background-size: cover;
+    -moz-background-size: cover;
+    background-size: cover;
+    -o-background-size: cover;
   }
-}
 
 
-#monarch-home-container ul.banner-social-buttons {
-  margin-top: 0;
-  @media(max-width:1199px) {
-    margin-top: 15px;
+  #monarch-home-container .partners-section {
+    padding: 50px 10px;
   }
-  @media(max-width:767px) {
-    li {
-      display: block;
-      margin-bottom: 20px;
-      padding: 0;
-      &:last-child {
-        margin-bottom: 0;
-      }
+
+  #monarch-home-container .btn.btn-dark {
+    text-transform: uppercase;
+    color: white;
+    font-family: "Montserrat","Helvetica Neue",Helvetica,Arial,sans-serif;
+    font-weight: 400;
+    -webkit-transition: all .3s ease-in-out;
+    -moz-transition: all .3s ease-in-out;
+    transition: all .3s ease-in-out;
+  }
+
+
+  #monarch-home-container footer.footer {
+    display: table;
+    width: 100%;
+    height: auto;
+    padding: 50px 0;
+    text-align: center;
+    color: white;
+    background-color: $monarch-bg-color;
+
+    a {
+      color: white;
     }
   }
-}
-
-#monarch-home-container footer {
-  padding: 50px 0;
-  p {
-    margin: 0;
-  }
-}
-
 </style>
+
+

--- a/ui/components/HomeFooter.vue
+++ b/ui/components/HomeFooter.vue
@@ -4,10 +4,10 @@
   <div class="row">
     <div class="col-12 col-lg-3">
       <div class="media">
-        <img class="img-fluid"
-        style="max-height:125px; margin:auto; padding:5px 5px 5px 5px;"
-        src="../assets/images/monarch-logo-white-stacked.png" 
-        alt="Monarch logo">
+        <img
+          class="img-fluid monarch-logo"
+          src="../assets/images/monarch-logo-white-stacked.png" 
+          alt="Monarch logo">
       </div>
     </div>
     <div class="col-12 col-md-4 col-lg-3 about-section">
@@ -85,16 +85,16 @@
 @import "../../css/_prelude-ng.scss";
 .home-footer {
   margin: 0px 15px;
-  padding: 25px 0px;
-  background: #15556A;
-  color: white;
+  padding: 15px 0px;
+  xbackground: $monarch-bg-color;
+  xcolor: white;
 }
 
 .about-section{
   padding-left: 25px;
 }
 
-@media (max-width: 770px) {
+@media (max-width:$grid-float-breakpoint) {
   .about-section {
     text-align: center;
   }
@@ -105,4 +105,12 @@
   margin: 0;
   color: white;
 }
+
+.monarch-logo {
+  max-height:125px;
+  margin:0 auto 20px auto;
+  padding:5px 5px 5px 5px;
+}
+
+
 </style>

--- a/ui/components/Node.vue
+++ b/ui/components/Node.vue
@@ -1,99 +1,35 @@
 <template>
+<!-- eslint-disable vue/html-indent -->
+
 <div id="selenium_id_content">
 
-<div>
-  <div class="nav-sidebar-vertical">
-    <ul class="list-group">
-      <li class="list-group-item list-group-item-node">
-        <a
-          target="_blank"
-          v-bind:href="'http://beta.monarchinitiative.org' + path">
-          <img
-            class="entity-type-icon"
-            :src="icons[nodeType]"/>
-          <span class="list-group-item-value">{{labels[nodeType]}}</span>
-        </a>
-      </li>
-
-      <li class="list-group-item list-group-item-squat">
-        <a
-          v-on:click="toggleSidebar()"
-          href="#">
-          <i class="fa fa-2x fa-crosshairs"></i>
-          <span class="list-group-item-value">Neighbors</span>
-        </a>
-      </li>
-
-      <li class="list-group-item list-group-item-squat"
-        v-bind:class="{ active: !expandedCard }">
-        <a
-          v-on:click="expandCard(null)"
-          href="#">
-          <i class="fa fa-2x fa-th-large"></i>
-          <span class="list-group-item-value">Overview</span>
-        </a>
-      </li>
-
-      <li class="list-group-item"
-        v-bind:class="{ active: expandedCard === cardType }"
-        v-for="cardType in nonEmptyCards"
-        :key="cardType">
-        <a
-          :href="'#' + cardType"
-          v-on:click="expandCard(cardType)">
-          <img class="entity-type-icon" :src="icons[cardType]"/>
-          <span class="list-group-item-value">{{labels[cardType]}} ({{counts[cardType]}})</span>
-        </a>
-      </li>
-      <li
-        class="node-filter-section">
-        <h5>Species</h5>
-        <assoc-facets v-model="facetObject.species">
-        </assoc-facets>
-      </li>
-    </ul>
-
-  </div>
-
-</div>
-
+<node-sidebar
+  v-if="node"
+  ref="sidebar"
+  :node-type="nodeType"
+  :node-label="nodeLabel"
+  :expanded-card="expandedCard"
+  :available-cards="availableCards"
+  :cards-to-display="nonEmptyCards"
+  :card-counts="counts"
+  :parent-node="node"
+  :parent-node-id="nodeId"
+  :facet-object="facetObject"
+  :is-neighborhood="isNeighborhood"
+  :subclasses="subclasses"
+  :superclasses="superclasses"
+  @expand-card="expandCard"
+  @toggle-neighborhood="toggleNeighborhood"
+  />
 
 <div class="container-cards">
 <div class="wrapper">
+
   <div
     class="overlay"
-    v-bind:class="{ active: isActive }"
-    v-on:click="toggleSidebar()">
+    :class="{ active: isNeighborhood }"
+    @click="toggleNeighborhood()">
   </div>
-  <nav
-    id="sidebar"
-    v-bind:class="{ active: isActive }">
-    <div class="sidebar-content">
-      <div class="row superclass" v-for="c in superclasses">
-        <div class="col-12">
-          <router-link
-            :to="'/' + nodeCategory + '/' + c.id">
-            {{c.label}}
-          </router-link>
-        </div>
-      </div>
-
-      <div class="row currentclass">
-        <div class="col-12">
-          {{nodeLabel}}
-        </div>
-      </div>
-
-      <div class="row subclass" v-for="c in subclasses">
-        <div class="col-12">
-          <router-link
-            :to="'/' + nodeCategory + '/' + c.id">
-            {{c.label}}
-          </router-link>
-        </div>
-      </div>
-    </div>
-  </nav>
 
   <div
     class="container-fluid title-bar">
@@ -103,25 +39,31 @@
         v-if="nodeError">
         <sm>
           <h6>
-            Error loading {{labels[nodeType]}}: {{nodeId}}
+            Error loading {{ labels[nodeType] }}: {{ nodeId }}
           </h6>
           <pre
-            class="pre-scrollable">{{nodeError}}</pre>
+            class="pre-scrollable">{{ nodeError }}</pre>
         </sm>
       </div>
       <div
         v-else>
-        <h5 class="text-center">Loading Data for {{labels[nodeType]}}: {{nodeId}}</h5>
+        <h5 class="text-center">Loading Data for {{ labels[nodeType] }}: {{ nodeId }}</h5>
       </div>
     </div>
 
     <div
       v-else>
 
-      <span><b>{{nodeLabel}}</b> ({{node.id}})</span>
+      <span><b>{{ nodeLabel }}</b> ({{ node.id }})</span>
       <br>
       <span><b>AKA:</b>&nbsp;</span>
-      <span class="synonym" v-for="s in synonyms">{{s}}</span>
+      <span
+        class="synonym"
+        v-for="s in synonyms"
+        :key="s"
+      >
+        {{ s }}
+      </span>
     </div>
   </div>
 
@@ -134,41 +76,42 @@
       class="node-content-section">
       <div class="col-12">
         <div class="node-description">
-          {{nodeDefinition}}
+          {{ nodeDefinition }}
         </div>
       </div>
 
       <div class="col-12">
         <b>References:</b>&nbsp;
         <span
-          v-for="r in xrefs">
+          v-for="r in xrefs"
+          :key="r">
           <router-link
             v-if="r.url.indexOf('/') === 0"
             :to="r.url">
-            {{r.label}}
+            {{ r.label }}
           </router-link>
 
           <a
             v-else-if="r.url && r.blank"
             :href="r.url"
             target="_blank">
-            {{r.label}}
+            {{ r.label }}
           </a>
           <a
             v-else-if="r.url"
             :href="r.url">
-            {{r.label}}
+            {{ r.label }}
           </a>
 
           <span
             v-else>
-            {{r.label}}
+            {{ r.label }}
           </span>
         </span>
         <br>
         <span
           v-if="inheritance">
-          <b>Heritability:</b>&nbsp;{{inheritance}}
+          <b>Heritability:</b>&nbsp;{{ inheritance }}
         </span>
       </div>
 
@@ -176,22 +119,23 @@
         <b>Equivalent IDs:</b>&nbsp;
 
         <span
-          v-for="r in equivalentClasses">
+          v-for="r in equivalentClasses"
+          :key="r">
           <router-link
             v-if="r.id"
             :to="'/resolve/' + r.id">
-            {{r.label || r.id}}
+            {{ r.label || r.id }}
           </router-link>
 
           <span
             v-else>
-            {{r.label}}
+            {{ r.label }}
           </span>
         </span>
         <br>
         <span
           v-if="inheritance">
-          <b>Heritability:</b>&nbsp;{{inheritance}}
+          <b>Heritability:</b>&nbsp;{{ inheritance }}
         </span>
       </div>
 
@@ -210,27 +154,29 @@
           :card-count="counts[cardType]"
           :parent-node="node"
           :parent-node-id="nodeId"
-          v-on:expandCard="expandCard(cardType)">
+          @expand-card="expandCard(cardType)">
         </node-card>
       </div>
     </div>
     <div v-if="!expandedCard">
-      <exac-gene :nodeID="nodeId"></exac-gene>
+      <exac-gene
+        :node-id="nodeId"/>
     </div>
     <div
       v-if="expandedCard"
       class="expanded-card-view col-12">
-      <h3 class="text-center">{{labels[expandedCard]}} Associations</h3>
+      <h3 class="text-center">{{ labels[expandedCard] }} Associations</h3>
       <assoc-table
               :facets="facetObject"
-              :nodeType="nodeCategory"
-              :cardType="expandedCard"
+              :node-type="nodeCategory"
+              :card-type="expandedCard"
               :identifier="nodeId"
       >
       </assoc-table>
     </div>
     <div v-if="!expandedCard && nodeCategory === 'variant'">
-      <exac-variant :nodeID="nodeId"></exac-variant>
+      <exac-variant
+        :node-id="nodeId"/>
     </div>
   </div>
 </div>
@@ -300,7 +246,7 @@ const labels = {
 
 
 export default {
-    name: 'home',
+  name: 'home',
   created() {
     // console.log('created', this.nodeId);
   },
@@ -317,7 +263,7 @@ export default {
     this.fetchData();
   },
   watch: {
-    '$route' (to, from) {
+    $route(to, _from) {
       // Only fetchData if the path is different.
       // hash changes are currently handled by monarch-tabs.js
       // within the loaded MonarchLegacy component.
@@ -327,60 +273,63 @@ export default {
       }
     }
   },
-  data () {
+
+  /* eslint quote-props: 0 */
+  data() {
     return {
+      isNeighborhood: false,
       facetObject: {
-          species: {'Anolis carolinensis': true,
-            'Arabidopsis thaliana': true,
-            'Bos taurus': true,
-            'Caenorhabditis elegans': true,
-            'Danio rerio': true,
-            'Drosophila melanogaster': true,
-            'Equus caballus': true,
-            'Gallus gallus': true,
-            'Homo sapiens': true,
-            'Macaca mulatta': true,
-            'Monodelphis domestica': true,
-            'Mus musculus': true,
-            'Ornithorhynchus anatinus': true,
-            'Pan troglodytes': true,
-            'Rattus norvegicus': true,
-            'Saccharomyces cerevisiae S288C': true,
-            'Sus scrofa': true,
-            'Xenopus (Silurana) tropicalis': true,
-          },
-          evidence: {
-              IEA: true,
-          },
-          systems: {
-              'Skeletal system': true,
-              'Limbs': true,
-              'Nervous system': true,
-              'Head or neck': true,
-              'Metabolism/homeostasis': true,
-              'Cardiovascular system': true,
-              'Integument': true,
-              'Genitourinary system': true,
-              'Eye': true,
-              'Musculature': true,
-              'Neoplasm': true,
-              'Digestive system': true,
-              'Immune System': true,
-              'Blood and blood-forming tissues': true,
-              'Endocrine': true,
-              'Respiratory system': true,
-              'Ear': true,
-              'Connective tissue': true,
-              'Prenatal development or birth': true,
-              'Growth': true,
-              'Constitutional': true,
-              'Thoracic cavity': true,
-              'Breast': true,
-              'Voice': true,
-              'Cellular': true,
-          },
+        species: {
+          'Anolis carolinensis': true,
+          'Arabidopsis thaliana': true,
+          'Bos taurus': true,
+          'Caenorhabditis elegans': true,
+          'Danio rerio': true,
+          'Drosophila melanogaster': true,
+          'Equus caballus': true,
+          'Gallus gallus': true,
+          'Homo sapiens': true,
+          'Macaca mulatta': true,
+          'Monodelphis domestica': true,
+          'Mus musculus': true,
+          'Ornithorhynchus anatinus': true,
+          'Pan troglodytes': true,
+          'Rattus norvegicus': true,
+          'Saccharomyces cerevisiae S288C': true,
+          'Sus scrofa': true,
+          'Xenopus (Silurana) tropicalis': true,
+        },
+        evidence: {
+          IEA: true,
+        },
+        systems: {
+          'Skeletal system': true,
+          'Limbs': true,
+          'Nervous system': true,
+          'Head or neck': true,
+          'Metabolism/homeostasis': true,
+          'Cardiovascular system': true,
+          'Integument': true,
+          'Genitourinary system': true,
+          'Eye': true,
+          'Musculature': true,
+          'Neoplasm': true,
+          'Digestive system': true,
+          'Immune System': true,
+          'Blood and blood-forming tissues': true,
+          'Endocrine': true,
+          'Respiratory system': true,
+          'Ear': true,
+          'Connective tissue': true,
+          'Prenatal development or birth': true,
+          'Growth': true,
+          'Constitutional': true,
+          'Thoracic cavity': true,
+          'Breast': true,
+          'Voice': true,
+          'Cellular': true,
+        },
       },
-      isActive: false,
       isSelected: {
         phenotypes: false,
         genes: false,
@@ -437,7 +386,7 @@ export default {
           field: 'source'
         }
       ],
-    }
+    };
   },
 
 
@@ -446,8 +395,8 @@ export default {
       this.expandedCard = cardType;
     },
 
-    toggleSidebar() {
-      this.isActive = !this.isActive;
+    toggleNeighborhood() {
+      this.isNeighborhood = !this.isNeighborhood;
     },
 
     // TIP/QUESTION: This applyResponse is called asynchronously via the function
@@ -560,7 +509,7 @@ export default {
       this.nodeError = null;
       this.expandedCard = null;
       this.nonEmptyCards = [];
-      this.isActive = false;
+      this.isNeighborhood = false;
       this.startProgress();
 
       try {
@@ -775,7 +724,7 @@ $title-bar-height: 70px;
   margin: 0;
   padding: 0;
   background-color: transparent;
-  border-color: #030303;
+  xborder-color: #030303;
 }
 
 .nav-sidebar-vertical li.list-group-item > a {
@@ -830,7 +779,7 @@ $title-bar-height: 70px;
 
 
 .nav-sidebar-vertical li.list-group-item.list-group-item-node {
-  background: black;
+  xbackground: black;
 }
 
 .nav-sidebar-vertical li.list-group-item.list-group-item-node > a {
@@ -903,7 +852,7 @@ div.panel.panel-default {
 }
 
 .nav-sidebar-vertical {
-  background: #292e34;
+  background: $monarch-bg-color;
   border-right: 1px solid #292e34;
   bottom: 0;
   left: 0;
@@ -911,7 +860,7 @@ div.panel.panel-default {
   overflow-y: auto;
   position: fixed;
   width: $sidebar-width;
-  top: ($navbar-height + 6);
+  top: ($navbar-height);
   z-index: 1000;
 }
 
@@ -965,14 +914,6 @@ table.fake-table-view td
 
 .btn-sidebar {
   border:1px solid red;
-}
-
-li.node-filter-section {
-  margin: 0;
-  padding: 5px 5px 5px 10px;
-  color: white;
-  border: solid black 1px;
-  border-bottom: solid black 2px;
 }
 
 @media (max-width: $grid-float-breakpoint) {

--- a/ui/components/NodeCard.vue
+++ b/ui/components/NodeCard.vue
@@ -1,33 +1,35 @@
 <template>
+  <!-- eslint-disable vue/html-indent -->
 
 <div class="node-card">
-
   <div
     class="card"
-    v-bind:class="{ active: isSelected }"
-    v-on:click="toggleSelected()">
+    :class="{ active: isSelected }"
+    @click="toggleSelected()">
     <h6 class="card-title card-header text-center py-0">
-      {{cardLabel}}
-      <img class="card-img-top" :src="cardIcon"/>
+      {{ cardLabel }}
+      <img
+        class="card-img-top"
+        :src="cardIcon"/>
     </h6>
     <div class="card-header text-center py-0">
     </div>
     <div class="card-body">
       <div class="card-text text-center">
-        {{cardCount}}
+        {{ cardCount }}
       </div>
     </div>
   </div>
 </div>
 </template>
 
-
-
 <script>
 
 export default {
   name: 'NodeCard',
 
+  /* eslint vue/require-default-prop: 0 */
+  /* eslint vue/require-prop-types: 0 */
   props: [
     'cardType',
     'cardCount',
@@ -49,12 +51,12 @@ export default {
     this.cardLabel = this.$parent.labels[this.cardType];
   },
 
-  data () {
+  data() {
     return {
       isSelected: false,
       cardIcon: null,
       cardLabel: null
-    }
+    };
   },
 
 
@@ -62,12 +64,12 @@ export default {
     toggleSelected() {
       this.isSelected = !this.isSelected;
       if (this.isSelected) {
-        this.$emit('expandCard', this);
+        this.$emit('expand-card', this);
       }
     },
   }
 
-}
+};
 
 </script>
 

--- a/ui/components/NodeSidebar.vue
+++ b/ui/components/NodeSidebar.vue
@@ -1,0 +1,448 @@
+<template>
+<!-- eslint-disable vue/html-indent -->
+<div>
+
+  <nav
+    id="sidebar"
+    :class="{ active: isNeighborhood }">
+    <div class="sidebar-content">
+      <div
+        class="row superclass"
+        v-for="c in superclasses"
+        :key="c">
+        <div class="col-12">
+          <router-link
+            :to="'/' + nodeType + '/' + c.id">
+            {{ c.label }}
+          </router-link>
+        </div>
+      </div>
+
+      <div class="row currentclass">
+        <div class="col-12">
+          {{ nodeLabel }}
+        </div>
+      </div>
+
+      <div
+        class="row subclass"
+        v-for="c in subclasses"
+        :key="c">
+        <div class="col-12">
+          <router-link
+            :to="'/' + nodeType + '/' + c.id">
+            {{ c.label }}
+          </router-link>
+        </div>
+      </div>
+    </div>
+  </nav>
+
+  <div class="nav-sidebar-vertical">
+    <ul
+      class="list-group"
+      v-if="nodeType">
+      <li class="list-group-item list-group-item-node">
+        <a
+          target="_blank"
+          :href="'http://beta.monarchinitiative.org' + $route.path">
+          <img
+            class="entity-type-icon"
+            :src="$parent.icons[nodeType]"/>
+          <span class="list-group-item-value">{{ $parent.labels[nodeType] }}</span>
+        </a>
+        <a
+          style="padding:0;height:0;width:100%;border:2px solid black;"
+          target="_blank"
+          :href="'http://alpha.monarchinitiative.org' + $route.path">
+        </a>
+      </li>
+
+      <li class="list-group-item list-group-item-squat">
+        <a
+          @click="toggleNeighborhood()"
+          href="#">
+          <i class="fa fa-2x fa-crosshairs"></i>
+          <span class="list-group-item-value">Neighbors</span>
+        </a>
+      </li>
+
+      <li class="list-group-item list-group-item-squat"
+        :class="{ active: !expandedCard }">
+        <a
+          @click="expandCard(null)"
+          href="#">
+          <i class="fa fa-2x fa-th-large"></i>
+          <span class="list-group-item-value">Overview</span>
+        </a>
+      </li>
+
+      <li class="list-group-item"
+        :class="{ active: expandedCard === cardType }"
+        v-for="cardType in cardsToDisplay"
+        :key="cardType">
+        <a
+          :href="'#' + cardType"
+          @click="expandCard(cardType)">
+          <img class="entity-type-icon" :src="$parent.icons[cardType]"/>
+          <span class="list-group-item-value">{{$parent.labels[cardType]}} ({{cardCounts[cardType]}})</span>
+        </a>
+      </li>
+      <li
+        class="node-filter-section">
+        <h5>Species</h5>
+
+        <assoc-facets
+          v-model="facetObject.species"/>
+      </li>
+    </ul>
+</div>
+
+</div>
+</template>
+
+<script>
+
+
+export default {
+  name: 'NodeSidebar',
+  created() {
+    // console.log('created', this.nodeId);
+  },
+
+  updated() {
+    // console.log('updated', this.nodeId);
+  },
+
+  destroyed() {
+    // console.log('destroyed', this.nodeId);
+  },
+
+  mounted() {
+  },
+
+  /* eslint vue/require-default-prop: 0 */
+  props: {
+    cardsToDisplay: Array,
+    expandedCard: String,
+    cardCounts: Object,
+    nodeType: String,
+    nodeLabel: String,
+    superclasses: Array,
+    subclasses: Array,
+    facetObject: Object,
+    isNeighborhood: Boolean
+  },
+
+  data() {
+    return {
+    };
+  },
+
+
+  methods: {
+    expandCard(cardType) {
+      this.$emit('expand-card', cardType);
+    },
+
+    toggleNeighborhood() {
+      // this.isNeighborhood = !this.isNeighborhood;
+      this.$emit('toggle-neighborhood');
+    },
+  }
+};
+
+</script>
+
+<style lang="scss">
+@import "../../css/_prelude-ng.scss";
+
+$sidebar-content-width: 500px;
+$sidebar-width: 200px;
+$collapsed-sidebar-width: 55px;
+$sidebar-button-width: 32px;
+$title-bar-height: 70px;
+
+#sidebar a,
+#sidebar a:hover,
+#sidebar a:focus {
+  color: inherit;
+  text-decoration: none;
+  transition: all 0.3s;
+}
+
+#sidebar a img.sidebar-logo {
+  margin: 0 0 0 0;
+  padding: 0;
+  height: 30px !important;
+}
+
+#sidebar {
+  width: $sidebar-content-width;
+  position: fixed;
+  top: ($navbar-height + 80);
+  left: (-$sidebar-content-width);
+  min-height: 40px;
+  z-index: 1050;
+  xcolor: #fff;
+  transition: all 0.3s;
+  overflow-y: auto;
+  overflow-x: hidden;
+  background: ghostwhite;
+  xpadding-left: $sidebar-button-width;
+}
+
+#sidebar.active {
+  left: 10px;
+  box-shadow: 3px 3px 3px rgba(0, 0, 0, 0.2);
+}
+
+
+#sidebar .sidebar-content {
+  width: ($sidebar-content-width - $sidebar-button-width);
+  margin: 0;
+}
+
+
+#sidebar.active .sidebar-content {
+  xdisplay:block;
+}
+
+#sidebar .sidebar-content .superclass {
+  margin-left: 0;
+}
+
+#sidebar .sidebar-content .currentclass {
+  font-weight: 600;
+  margin-left: 15px;
+}
+
+#sidebar .sidebar-content .subclass {
+  margin-left: 30px;
+}
+
+.overlay {
+    position: fixed;
+    width: 100vw;
+    height: 100vh;
+    background: rgba(0, 0, 0, 0.3);
+    z-index: 50;
+    display: none;
+}
+
+.overlay.active {
+    display: initial;
+}
+
+#sidebar ul li a {
+    text-align: left;
+}
+
+#sidebar.active ul li a {
+    padding: 20px 10px;
+    text-align: center;
+    font-size: 0.85em;
+}
+
+#sidebar.active ul li a i {
+    margin-right:  0;
+    display: block;
+    font-size: 1.8em;
+    margin-bottom: 5px;
+}
+
+#sidebar.active ul ul a {
+    padding: 10px !important;
+}
+
+#sidebar.active a[aria-expanded="false"]::before,
+#sidebar.active a[aria-expanded="true"]::before {
+    top: auto;
+    bottom: 5px;
+    right: 50%;
+    -webkit-transform: translateX(50%);
+    -ms-transform: translateX(50%);
+    transform: translateX(50%);
+}
+
+#sidebar ul.components {
+    padding: 20px 0;
+    border-bottom: 1px solid #47748b;
+}
+
+#sidebar ul li a {
+    padding: 10px;
+    font-size: 1.1em;
+    display: block;
+}
+#sidebar ul li a:hover {
+    color: #7386D5;
+    background: #fff;
+}
+#sidebar ul li a i {
+    margin-right: 10px;
+}
+
+#sidebar ul li.active > a,
+#sidbar a[aria-expanded="true"] {
+    color: #fff;
+    background: #6d7fcc;
+}
+
+
+#sidebar a[data-toggle="collapse"] {
+    position: relative;
+}
+
+#sidebar a[aria-expanded="false"]::before,
+#sidebar a[aria-expanded="true"]::before {
+    content: '\e259';
+    display: block;
+    position: absolute;
+    right: 20px;
+    font-family: 'Glyphicons Halflings';
+    font-size: 0.6em;
+}
+#sidebar a[aria-expanded="true"]::before {
+    content: '\e260';
+}
+
+
+#sidebar ul ul a {
+    font-size: 0.9em !important;
+    padding-left: 30px !important;
+    background: #6d7fcc;
+}
+
+#sidebar a.download {
+    background: #fff;
+    color: #7386D5;
+}
+
+#sidebar a.article,
+#sidebar a.article:hover {
+    background: #6d7fcc !important;
+    color: #fff !important;
+}
+
+.nav-sidebar-vertical .node-filter-section {
+  padding: 0;
+  margin-top: 10px;
+  height: 250px;
+  overflow-y: scroll;
+  color: white;
+}
+
+.nav-sidebar-vertical li.list-group-item {
+  margin: 0;
+  padding: 0;
+  background-color: transparent;
+  xborder-color: #030303;
+}
+
+.nav-sidebar-vertical li.list-group-item > a {
+  background-color: transparent;
+  color: #d1d1d1;
+  cursor: pointer;
+  display: block;
+  font-size: 16px;
+  font-weight: 400;
+  height: 63px;
+  line-height: 26px;
+  padding: 17px 20px 17px 25px;
+  position: relative;
+  white-space: nowrap;
+  width: $sidebar-width;
+  text-decoration: none;
+  margin: 0;
+  padding: 2px 0 0 6px;
+  height: 35px;
+}
+
+
+.nav-sidebar-vertical li.list-group-item > a:hover {
+  color: #fff;
+  font-weight: 600
+}
+
+.nav-sidebar-vertical li.list-group-item.active > a {
+  background-color: #393f44;
+  color: #fff;
+  font-weight: 600
+}
+
+.nav-sidebar-vertical li.list-group-item.active > a:before {
+  background: #39a5dc;
+  content: " ";
+  height: 100%;
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 3px;
+}
+
+.nav-sidebar-vertical li.list-group-item > a img.entity-type-icon {
+  margin: 0 5px;
+  padding: 0;
+  height: 30px;
+}
+
+
+.nav-sidebar-vertical li.list-group-item.list-group-item-node {
+}
+
+.nav-sidebar-vertical li.list-group-item.list-group-item-node > a {
+  text-transform: uppercase;
+  vertical-align: bottom;
+  height: 30px;
+}
+
+.nav-sidebar-vertical li.list-group-item.list-group-item-node img.entity-type-icon {
+  margin: 0;
+  height: 28px;
+}
+
+
+.nav-sidebar-vertical li.list-group-item.list-group-item-squat {
+}
+
+.nav-sidebar-vertical li.list-group-item.list-group-item-squat > a {
+  padding: 0;
+}
+
+.nav-sidebar-vertical li.list-group-item.list-group-item-squat > a i.fa {
+  margin: 2px 8px 0 12px;
+  padding: 0;
+}
+
+.nav-sidebar-vertical li.list-group-item.list-group-item-squat > a .list-group-item-value {
+  padding: 0;
+  vertical-align:text-bottom;
+}
+
+
+.nav-sidebar-vertical li.list-group-item.list-group-item-squat > a {
+  height: 35px;
+}
+
+.nav-sidebar-vertical li.list-group-item.list-group-item-squat > a > i {
+  margin: 5px 0 0 5px;
+}
+
+.nav-sidebar-vertical li.list-group-item > a .list-group-item-value {
+  margin: 2px 0 0 5px;
+}
+
+
+@media (max-width: $grid-float-breakpoint) {
+  .nav-sidebar-vertical {
+    width: $collapsed-sidebar-width;
+  }
+
+  .nav-sidebar-vertical li.list-group-item > a .list-group-item-value {
+    display: none;
+  }
+}
+
+</style>
+

--- a/ui/main.js
+++ b/ui/main.js
@@ -15,6 +15,7 @@ import Home from '@/components/Home.vue';
 import HomeFooter from '@/components/HomeFooter.vue';
 import Navbar from '@/components/Navbar.vue';
 import Node from '@/components/Node.vue';
+import NodeSidebar from '@/components/NodeSidebar.vue';
 import NodeCard from '@/components/NodeCard.vue';
 import MonarchLegacy from '@/components/MonarchLegacy.vue';
 import AssocTable from '@/components/AssocTable.vue';
@@ -111,6 +112,7 @@ const main = () => {
   Vue.use(VueFormWizard);
 
   Vue.component('monarch-navbar', Navbar);
+  Vue.component('node-sidebar', NodeSidebar);
   Vue.component('node-card', NodeCard);
   Vue.component('assoc-table', AssocTable);
   Vue.component('assoc-facets', AssocFacets);


### PR DESCRIPTION
- Disables various vue-related errors in ui/.eslintrc
- Adds definition of monarch-bg-color to prelude-ng.scss
- Adjust grid breakpoints in prelude-ng.scss
- Enable SCSS style for AssocFacets.vue. Disable scoped style
- Handle bad BioLink response better in AssocTable.vue
- Use NodeId instead of NodeID for vue compatibility
- Isolate the sidebar code into NodeSidebar.vue
- Clean up home page. Use SCSS. Remove dead code. Ensure footer is full-width.