### PR TITLE
AssocTable styling. Home Page Search. BioLink paging.

### DIFF
--- a/conf/server_config_beta.json
+++ b/conf/server_config_beta.json
@@ -7,9 +7,9 @@
 
     "scigraph_data_url" : "https://scigraph-data-dev.monarchinitiative.org/scigraph/",
 
-    "golr_url" : "https://solr-dev.monarchinitiative.org/solr/golr/",
+    "golr_url" : "https://solr.monarchinitiative.org/solr/golr/",
 
-    "search_url" : "https://solr-dev.monarchinitiative.org/solr/search/",
+    "search_url" : "https://solr.monarchinitiative.org/solr/search/",
 
     "owlsim_services_url" : "https://beta.monarchinitiative.org/owlsim",
 

--- a/css/_prelude-ng.scss
+++ b/css/_prelude-ng.scss
@@ -13,6 +13,20 @@ $grid-breakpoints: (
   xs: 0,
   sm: 576px,
   md: 768px,
-  lg: 950px, // Original BS4 value: 992px
+  monarch: 860px,
+  lg: 992px,
   xl: 1200px
 ) !default;
+
+/*
+original
+
+$grid-breakpoints: (
+  xs: 0,
+  sm: 576px,
+  md: 768px,
+  lg: 992px,
+  xl: 1200px
+) !default;
+
+*/

--- a/js/MonarchAccess/index.js
+++ b/js/MonarchAccess/index.js
@@ -93,7 +93,12 @@ export function getNodeAssociations(nodeType, identifier, biolinkAnnotationSuffi
   const urlExtension = `${nodeType}/${identifier}/${biolinkAnnotationSuffix}`;
 
   const returnedPromise = new Promise((resolve, reject) => {
-    axios.get(`${baseUrl}${urlExtension}`, { params })
+    axios.get(
+      `${baseUrl}${urlExtension}`,
+      {
+        params
+      }
+    )
       .then(resp => {
         const responseData = resp;
         if (typeof responseData !== 'object') {

--- a/lib/monarch/api.js
+++ b/lib/monarch/api.js
@@ -2822,6 +2822,9 @@ bbop.monarch.Engine.prototype.search = function(term, filters, facets, rows, sta
 
     searchGolrManager.set_results_count(limit);
     if(category != "" && category != null && category != undefined) {
+        if (category === 'phenotype') {
+            category = 'Phenotype';
+        }
         searchGolrManager.add_query_filter("category", category);
     }
 

--- a/lib/monarch/api.js
+++ b/lib/monarch/api.js
@@ -4147,6 +4147,22 @@ bbop.monarch.Engine.prototype.fetchAssociationCount = function(filter, facet, or
     return count;
 }
 
+
+
+bbop.monarch.Engine.prototype.fetchAssociationCounts = function(filter, facet, orFilter) {
+    var golrResponse = this.fetchAssociations(filter, 0, null, facet, orFilter);
+    var totalCount = golrResponse.total_documents();
+    var facetCount = totalCount;
+    if (facet != null){
+        var facet_list = golrResponse.facet_field(facet);
+        facetCount = facet_list.length;
+    }
+    return {
+        facetCount: facetCount,
+        totalCount: totalCount
+    };
+}
+
 /*
  * Function: fetchCoreDiseaseInfo
  *

--- a/lib/monarch/web/webapp.js
+++ b/lib/monarch/web/webapp.js
@@ -1,3 +1,5 @@
+/* eslint indent: 0 */
+
  /*
     Monarch WebApp
 
@@ -2971,7 +2973,7 @@ if (useSPA) {
     };
     const anatomyFilter = anatomyFilters[nodetype];
     if (anatomyFilter) {
-      info.anatomyNum = engine.fetchAssociationCount(anatomyFilter.slice(1), anatomyFilter[0]);
+      info.anatomyNum = engine.fetchAssociationCounts(anatomyFilter.slice(1), anatomyFilter[0]);
     }
 
 
@@ -3007,7 +3009,7 @@ if (useSPA) {
     };
     const diseaseFilter = diseaseFilters[nodetype];
     if (diseaseFilter) {
-      info.diseaseNum = engine.fetchAssociationCount(diseaseFilter.slice(1), diseaseFilter[0]);
+      info.diseaseNum = engine.fetchAssociationCounts(diseaseFilter.slice(1), diseaseFilter[0]);
     }
 
 
@@ -3023,7 +3025,7 @@ if (useSPA) {
     };
     const functionFilter = functionFilters[nodetype];
     if (functionFilter) {
-      info.functionNum = engine.fetchAssociationCount(functionFilter.slice(1), functionFilter[0]);
+      info.functionNum = engine.fetchAssociationCounts(functionFilter.slice(1), functionFilter[0]);
     }
 
 
@@ -3059,7 +3061,7 @@ if (useSPA) {
     };
     const geneFilter = geneFilters[nodetype];
     if (geneFilter) {
-      info.geneNum = engine.fetchAssociationCount(geneFilter.slice(1), geneFilter[0]);
+      info.geneNum = engine.fetchAssociationCounts(geneFilter.slice(1), geneFilter[0]);
     }
 
 
@@ -3093,7 +3095,7 @@ if (useSPA) {
     };
     const genotypeFilter = genotypeFilters[nodetype];
     if (genotypeFilter) {
-      info.genotypeNum = engine.fetchAssociationCount(genotypeFilter.slice(1), genotypeFilter[0]);
+      info.genotypeNum = engine.fetchAssociationCounts(genotypeFilter.slice(1), genotypeFilter[0]);
     }
 
 
@@ -3108,7 +3110,7 @@ if (useSPA) {
     };
     const homologFilter = homologFilters[nodetype];
     if (homologFilter) {
-      info.homologNum = engine.fetchAssociationCount(homologFilter.slice(1), homologFilter[0]);
+      info.homologNum = engine.fetchAssociationCounts(homologFilter.slice(1), homologFilter[0]);
     }
 
 
@@ -3124,7 +3126,7 @@ if (useSPA) {
     };
     const interactionFilter = interactionFilters[nodetype];
     if (interactionFilter) {
-      info.interactionNum = engine.fetchAssociationCount(interactionFilter.slice(1), interactionFilter[0]);
+      info.interactionNum = engine.fetchAssociationCounts(interactionFilter.slice(1), interactionFilter[0]);
     }
 
 
@@ -3139,7 +3141,7 @@ if (useSPA) {
     };
     const literatureFilter = literatureFilters[nodetype];
     if (literatureFilter) {
-      info.literatureNum = engine.fetchAssociationCount(literatureFilter.slice(1), literatureFilter[0]);
+      info.literatureNum = engine.fetchAssociationCounts(literatureFilter.slice(1), literatureFilter[0]);
     }
 
     const modelFilters = {
@@ -3173,7 +3175,7 @@ if (useSPA) {
     };
     const modelFilter = modelFilters[nodetype];
     if (modelFilter) {
-      info.modelNum = engine.fetchAssociationCount(modelFilter.slice(1), modelFilter[0]);
+      info.modelNum = engine.fetchAssociationCounts(modelFilter.slice(1), modelFilter[0]);
     }
 
 
@@ -3186,7 +3188,7 @@ if (useSPA) {
     };
     const orthoPhenotypeFilter = orthoPhenotypeFilters[nodetype];
     if (orthoPhenotypeFilter) {
-      info.orthoPhenotypeNum = engine.fetchAssociationCount(orthoPhenotypeFilter.slice(1), orthoPhenotypeFilter[0]);
+      info.orthoPhenotypeNum = engine.fetchAssociationCounts(orthoPhenotypeFilter.slice(1), orthoPhenotypeFilter[0]);
       info.orthoPhenoNum = info.orthoPhenotypeNum;  // ick. Legacy inconsistent name
     }
 
@@ -3199,7 +3201,7 @@ if (useSPA) {
     };
     const orthoDiseaseFilter = orthoDiseaseFilters[nodetype];
     if (orthoDiseaseFilter) {
-      info.orthoDiseaseNum = engine.fetchAssociationCount(orthoDiseaseFilter.slice(1), orthoDiseaseFilter[0]);
+      info.orthoDiseaseNum = engine.fetchAssociationCounts(orthoDiseaseFilter.slice(1), orthoDiseaseFilter[0]);
     }
 
     const pathwayFilters = {
@@ -3217,7 +3219,7 @@ if (useSPA) {
     };
     const pathwayFilter = pathwayFilters[nodetype];
     if (pathwayFilter) {
-      info.pathwayNum = engine.fetchAssociationCount(pathwayFilter.slice(1), pathwayFilter[0]);
+      info.pathwayNum = engine.fetchAssociationCounts(pathwayFilter.slice(1), pathwayFilter[0]);
     }
 
 
@@ -3253,7 +3255,7 @@ if (useSPA) {
     };
     const phenotypeFilter = phenotypeFilters[nodetype];
     if (phenotypeFilter) {
-      info.phenotypeNum = engine.fetchAssociationCount(phenotypeFilter.slice(1), phenotypeFilter[0]);
+      info.phenotypeNum = engine.fetchAssociationCounts(phenotypeFilter.slice(1), phenotypeFilter[0]);
     }
 
     const variantFilters = {
@@ -3287,7 +3289,7 @@ if (useSPA) {
     };
     const variantFilter = variantFilters[nodetype];
     if (variantFilter) {
-      info.variantNum = engine.fetchAssociationCount(variantFilter.slice(1), variantFilter[0]);
+      info.variantNum = engine.fetchAssociationCounts(variantFilter.slice(1), variantFilter[0]);
     }
   }
 
@@ -3344,6 +3346,7 @@ if (useSPA) {
 }
 
 
+
 function diseaseByIdHandler(request, id, fmt) {
     // engine.log("getting /disease/:id where id="+id + " fmt=" + fmt);
 
@@ -3358,6 +3361,7 @@ function diseaseByIdHandler(request, id, fmt) {
 
     // Rendering.
     const info = newInfo(engine.fetchClassInfo(cliqueLeader, {level:1}));
+
     const inheritanceList = engine.fetchInheritance(cliqueLeader);
 
 

--- a/templates/literature.mustache
+++ b/templates/literature.mustache
@@ -4,15 +4,14 @@
   <div class="container-fluid monarch-container">
 
     <div class="content">
-           <div class="jumbotron">
+           <div class="card bg-light pt-3 px-3 m-0">
                 <div id="description">
                     {{#alerts}}
                     <div class="alert alert-warning alert-block top-alert">
                         {{{.}}}
                     </div>
                     {{/alerts}}
-                    <img id="monarch-logo" class="downloadline" src="/image/logo.png"/>
-                    <h1 class="downloadline">{{publicationTitle}}</h1>
+                    <h4 class="downloadline">{{publicationTitle}}</h4>
                     <p>
                         <b>Authors</b>: {{{authorSpan}}}</br>
                         <b>Journal</b>: {{journal}} ({{year}})

--- a/templates/navbar.mustache
+++ b/templates/navbar.mustache
@@ -1,6 +1,6 @@
 <nav
   id="monarch-navbar"
-  class="navbar fixed-top navbar-expand-lg navbar-dark bg-dark">
+  class="navbar fixed-top navbar-expand-sm navbar-dark bg-dark">
 
   <a class="navbar-brand" href="/">
       <img class="branding-logo pull-left"

--- a/ui/.eslintrc
+++ b/ui/.eslintrc
@@ -23,6 +23,7 @@
     "vue/html-indent": 1,
     "global-require": 0,
     "no-unused-vars": [0, { "argsIgnorePattern": "^_" }],
+    "quote-props": [0]
   },
   "extends": [
     "plugin:vue/strongly-recommended",

--- a/ui/components/AssocTable.vue
+++ b/ui/components/AssocTable.vue
@@ -2,25 +2,39 @@
   <div>
     <div v-show="dataFetched">
       <h5>
-        <strong>{{ rows.length }}</strong>
+        <strong>{{ totalItems }}</strong>
         <strong>{{ nodeType }}</strong> to
         <strong>{{ cardType }}</strong> associations
       </h5>
       <b-table
-        :items="rows"
+        ref="tableRef"
+        :items="rowsProvider"
         :fields="fields"
         responsive="true"
-        class="table-border-soft"
+        class="table-sm table-border-soft"
         @row-clicked="rowClickHandler"
         :current-page="currentPage"
         :per-page="rowsPerPage"
       >
+
         <template
-          slot="index"
-          slot-scope="data"
+          slot="show_details"
+          slot-scope="row"
         >
-          {{data.item.recordIndex}}
+          <button
+            class="btn btn-xs btn-toggle"
+            @click="row.toggleDetails">
+            <i
+              class="fa fa-fw"
+              v-bind:class="{
+                'fa-chevron-down': row.detailsShowing,
+                'fa-chevron-right': !row.detailsShowing
+                }"
+            >
+            </i>
+          </button>
         </template>
+
         <template
           slot="assocObject"
           slot-scope="data"
@@ -57,27 +71,13 @@
           ({{data.item.sourcesLength}})
         </template>
         <template
-          slot="show_details"
-          slot-scope="row"
-        >
-          <div @click="row.toggleDetails">
-            <div
-              class="fa"
-              v-bind:class="{
-                'fa-angle-down': row.detailsShowing,
-                'fa-angle-right': !row.detailsShowing
-                }"
-            >
-            </div>
-          </div>
-        </template>
-        <template
           slot="row-details"
           slot-scope="row"
         >
-          <div class="card">
+          <div class="card ml-4 border border-secondary">
             <b-table
-              :fields="fields.slice(-4,-1)"
+              class="table-sm"
+              :fields="fields.slice(-3)"
               :items="[row.item]"
               fixed
             >
@@ -136,14 +136,14 @@
           </div>
         </template>
       </b-table>
-      <div v-if="rows.length > 10">
+      <div v-if="totalItems > rowsPerPage">
         <b-pagination
           class="pag-width my-1"
           align="center"
           size="md"
           v-model="currentPage"
           :per-page="rowsPerPage"
-          :total-rows="rows.length"
+          :total-rows="totalItems"
         >
         </b-pagination>
       </div>
@@ -167,393 +167,406 @@
 </template>
 
 <script>
-  import * as MA from '../../js/MonarchAccess';
-  export default {
-    data() {
-      return {
-        rowsPerPage: 10,
-        inverted: false,
-        rowClicked: false,
-        isGene: false,
-        currentPage: 1,
-        dataPacket: '',
-        dataFetched: false,
-        dataError: false,
-        fields: '',
-        rows: [],
-        taxonFields: [
-          'gene',
-          'genotype',
-          'model',
-          'variant',
-          'homolog',
-        ],
-      };
+import * as MA from '../../js/MonarchAccess';
+export default {
+  data() {
+    return {
+      currentPage: 1,
+      rowsPerPage: 25,
+      totalItems: 0,
+      inverted: false,
+      rowClicked: false,
+      isGene: false,
+      dataPacket: '',
+      dataFetched: false,
+      dataError: false,
+      fields: '',
+      rows: [],
+      taxonFields: [
+        'gene',
+        'genotype',
+        'model',
+        'variant',
+        'homolog',
+      ],
+    };
+  },
+  props: {
+    identifier: {
+      type: String,
+      required: true,
     },
-    props: {
-      identifier: {
-        type: String,
-        required: true,
-      },
-      cardType: {
-        type: String,
-        required: true,
-      },
-      nodeType: {
-        type: String,
-        required: true,
-      },
-      facets: {
-        type: Object,
-        default: null,
-        required: false,
-      },
+    cardType: {
+      type: String,
+      required: true,
     },
-    computed: {
-      trueFacets() {
-        const truth = [];
-        Object.entries(this.facets.species)
-          .forEach((elem) => {
-            if (elem[1]) {
-              truth.push(this.keyMap(elem[0]));
-            }
-          });
-        return truth;
-      }
+    nodeType: {
+      type: String,
+      required: true,
     },
-    mounted() {
-      this.generateFields();
-      this.handleSubjectObjectInversion();
-      this.fetchData();
+    facets: {
+      type: Object,
+      default: null,
+      required: false,
     },
-    methods: {
-      keyMap(key) {
-        const keyMappings = {
-          'Skeletal system': 'HP:0000924',
-          'Limbs': 'HP:0040064',
-          'Nervous system': 'HP:0000707',
-          'Head or neck': 'HP:0000152',
-          'Metabolism/homeostasis': 'HP:0001939',
-          'Cardiovascular system': 'HP:0001626',
-          'Integument': 'HP:0001574',
-          'Genitourinary system': 'HP:0000119',
-          'Eye': 'HP:0000478',
-          'Musculature': 'HP:0003011',
-          'Neoplasm': 'HP:0002664',
-          'Digestive system': 'HP:0025031',
-          'Immune System': 'HP:0002715',
-          'Blood and blood-forming tissues': 'HP:0001871',
-          'Endocrine': 'HP:0000818',
-          'Respiratory system': 'HP:0002086',
-          'Ear': 'HP:0000598',
-          'Connective tissue': 'HP:0003549',
-          'Prenatal development or birth': 'HP:0001197',
-          'Growth': 'HP:0001507',
-          'Constitutional': 'HP:0025142',
-          'Thoracic cavity': 'HP:0045027',
-          'Breast': 'HP:0000769',
-          'Voice': 'HP:0001608',
-          'Cellular': 'HP:0025354',
-          'Anolis carolinensis': 'NCBITaxon:28377',
-          'Arabidopsis thaliana': 'NCBITaxon:3702',
-          'Bos taurus': 'NCBITaxon:9913',
-          'Caenorhabditis elegans': 'NCBITaxon:6239',
-          'Danio rerio': 'NCBITaxon:7955',
-          'Drosophila melanogaster': 'NCBITaxon:7227',
-          'Equus caballus': 'NCBITaxon:9796',
-          'Gallus gallus': 'NCBITaxon:9031',
-          'Homo sapiens': 'NCBITaxon:9606',
-          'Macaca mulatta': 'NCBITaxon:9544',
-          'Monodelphis domestica': 'NCBITaxon:13616',
-          'Mus musculus': 'NCBITaxon:10090',
-          'Ornithorhynchus anatinus': 'NCBITaxon:9258',
-          'Pan troglodytes': 'NCBITaxon:9598',
-          'Rattus norvegicus': 'NCBITaxon:10116',
-          'Saccharomyces cerevisiae S288C': 'NCBITaxon:559292',
-          'Sus scrofa': 'NCBITaxon:9823',
-          'Xenopus (Silurana) tropicalis': 'NCBITaxon:8364',
-        };
-        return keyMappings[key];
-      },
-      rowClickHandler(record, index, event){
-        this.rowClicked = !this.rowClicked;
-      },
-      handleSubjectObjectInversion() {
-        const invertedCalls = [
-          {
-            'object': 'genotype',
-            'subject': 'gene',
-          },
-          {
-            'object': 'literature',
-            'subject': 'gene',
-          },
-          {
-            'object': 'model',
-            'subject': 'gene',
-          },
-          {
-            'object': 'variant',
-            'subject': 'gene',
-          },
-          {
-            'object': 'gene',
-            'subject': 'disease',
-          },
-          {
-            'object': 'model',
-            'subject': 'disease',
-          },
-          {
-            'object': 'genotype',
-            'subject': 'disease',
-          },
-          {
-            'object': 'literature',
-            'subject': 'disease',
-          },
-          {
-            'object': 'variant',
-            'subject': 'disease',
-          },
-          {
-            'object': 'disease',
-            'subject': 'phenotype',
-          },
-          {
-            'object': 'gene',
-            'subject': 'phenotype',
-          },
-          {
-            'object': 'genotype',
-            'subject': 'phenotype',
-          },
-          {
-            'object': 'literature',
-            'subject': 'phenotype',
-          },
-          {
-            'object': 'variant',
-            'subject': 'phenotype',
-          },
-          {
-            'object': 'gene',
-            'subject': 'goterm',
-          },
-          {
-            'object': 'literature',
-            'subject': 'model',
-          },
-        ];
-        this.inverted = false;
-        invertedCalls.forEach((elem) => {
-          if (this.nodeType === elem.subject && this.cardType === elem.object) {
-            this.inverted = true;
-          }
-        })
-      },
-      async fetchData() {
-        const that = this;
-        try {
-          const biolinkAnnotationSuffix = this.getBiolinkAnnotation(this.cardType);
-          const params= {
-            fetch_objects: true,
-              rows: 1000,
-          };
-          let searchResponse = await MA.getNodeAssociations(
-            this.nodeType,
-            this.identifier,
-            biolinkAnnotationSuffix,
-            params
-          );
-          // console.log('searchResponse');
-          // console.log(JSON.stringify(searchResponse, null, 2));
-          if (!searchResponse.data ||
-              !searchResponse.data.associations) {
-            that.dataPacket = null;
-            throw new Error('MA.getNodeAssociations() returned no data');
-          }
-          that.dataPacket = searchResponse;
-          that.dataFetched = true;
-          that.currentPage = 1;
-          that.populateRows();
-        }
-        catch (e) {
-          that.dataError = e;
-          // console.log('BioLink Error', e);
-        }
-
-      },
-      populateRows() {
-        this.rows = [];
-        let count = 0;
-        this.dataPacket.data.associations.forEach((elem) => {
-          count += 1;
-          let pubs = [
-            'No References',
-          ];
-          let pubsLength = 0;
-          if (elem.publications) {
-            pubs = this.parsePublications(elem.publications);
-            pubsLength += pubs.length;
-          }
-          let evidence = [
-            {
-              lbl: 'No Evidence',
-              id: '',
-            }
-          ];
-          let evidenceLength = 0;
-          const eviResults = this.parseEvidence(elem.evidence_graph.nodes);
-          if (eviResults.length) {
-            evidence = eviResults;
-            evidenceLength += eviResults.length;
-          }
-          let objectElem = elem.object;
-          if (this.inverted) {
-            objectElem = elem.subject;
-          }
-          const taxon = this.parseTaxon(objectElem);
-
-          if (!taxon.id || this.trueFacets.includes(taxon.id)) {
-            this.rows.push({
-              recordIndex: count,
-              references: pubs,
-              referencesLength: pubsLength,
-              annotationType: this.cardType,
-              evidence: evidence,
-              evidenceLength: evidenceLength,
-              objectCurie: objectElem.id,
-              sources: elem.provided_by,
-              sourcesLength: elem.provided_by.length,
-              assocObject: objectElem.label,
-              objectLink:`/${this.cardType}/${objectElem.id}`,
-              taxonLabel: taxon.label,
-              taxonId: taxon.id,
-              relationId: elem.relation.id,
-              relationLabel: elem.relation.label,
-            });
+  },
+  computed: {
+    trueFacets() {
+      const truth = [];
+      Object.entries(this.facets.species)
+        .forEach(elem => {
+          if (elem[1]) {
+            truth.push(this.keyMap(elem[0]));
           }
         });
-      },
-      generateFields() {
-        this.isGene = false;
-        const fields = [
-          {
-            key: 'recordIndex',
-            label: 'Index',
-            sortable: true,
-          },
-          {
-            key: 'assocObject',
-            label: this.firstCap(this.cardType),
-            'class': 'assoc-column-width ',
-            sortable: true,
-          },
-          {
-            key: 'evidence',
-            label: 'Evidence',
-          },
-          {
-            key: 'references',
-            label: 'References',
-          },
-          {
-            key: 'sources',
-            label: 'Sources',
-          },
-          {
-            key: 'show_details',
-            label: '',
-          },
+      return truth;
+    }
+  },
+  mounted() {
+    this.generateFields();
+    this.handleSubjectObjectInversion();
+    // this.fetchData();
+  },
+  methods: {
+    rowsProvider(ctx, callback) {
+      // console.log('rowsProvider', ctx);
+      // debugger;
+      this.fetchData().then(data => {
+        callback(this.rows)
+      }).catch(error => {
+        callback([])
+      });
+    },
+
+    keyMap(key) {
+      const keyMappings = {
+        'Skeletal system': 'HP:0000924',
+        'Limbs': 'HP:0040064',
+        'Nervous system': 'HP:0000707',
+        'Head or neck': 'HP:0000152',
+        'Metabolism/homeostasis': 'HP:0001939',
+        'Cardiovascular system': 'HP:0001626',
+        'Integument': 'HP:0001574',
+        'Genitourinary system': 'HP:0000119',
+        'Eye': 'HP:0000478',
+        'Musculature': 'HP:0003011',
+        'Neoplasm': 'HP:0002664',
+        'Digestive system': 'HP:0025031',
+        'Immune System': 'HP:0002715',
+        'Blood and blood-forming tissues': 'HP:0001871',
+        'Endocrine': 'HP:0000818',
+        'Respiratory system': 'HP:0002086',
+        'Ear': 'HP:0000598',
+        'Connective tissue': 'HP:0003549',
+        'Prenatal development or birth': 'HP:0001197',
+        'Growth': 'HP:0001507',
+        'Constitutional': 'HP:0025142',
+        'Thoracic cavity': 'HP:0045027',
+        'Breast': 'HP:0000769',
+        'Voice': 'HP:0001608',
+        'Cellular': 'HP:0025354',
+        'Anolis carolinensis': 'NCBITaxon:28377',
+        'Arabidopsis thaliana': 'NCBITaxon:3702',
+        'Bos taurus': 'NCBITaxon:9913',
+        'Caenorhabditis elegans': 'NCBITaxon:6239',
+        'Danio rerio': 'NCBITaxon:7955',
+        'Drosophila melanogaster': 'NCBITaxon:7227',
+        'Equus caballus': 'NCBITaxon:9796',
+        'Gallus gallus': 'NCBITaxon:9031',
+        'Homo sapiens': 'NCBITaxon:9606',
+        'Macaca mulatta': 'NCBITaxon:9544',
+        'Monodelphis domestica': 'NCBITaxon:13616',
+        'Mus musculus': 'NCBITaxon:10090',
+        'Ornithorhynchus anatinus': 'NCBITaxon:9258',
+        'Pan troglodytes': 'NCBITaxon:9598',
+        'Rattus norvegicus': 'NCBITaxon:10116',
+        'Saccharomyces cerevisiae S288C': 'NCBITaxon:559292',
+        'Sus scrofa': 'NCBITaxon:9823',
+        'Xenopus (Silurana) tropicalis': 'NCBITaxon:8364',
+      };
+      return keyMappings[key];
+    },
+    rowClickHandler(record, index, event) {
+      this.rowClicked = !this.rowClicked;
+    },
+    handleSubjectObjectInversion() {
+      const invertedCalls = [
+        {
+          'object': 'genotype',
+          'subject': 'gene',
+        },
+        {
+          'object': 'literature',
+          'subject': 'gene',
+        },
+        {
+          'object': 'model',
+          'subject': 'gene',
+        },
+        {
+          'object': 'variant',
+          'subject': 'gene',
+        },
+        {
+          'object': 'gene',
+          'subject': 'disease',
+        },
+        {
+          'object': 'model',
+          'subject': 'disease',
+        },
+        {
+          'object': 'genotype',
+          'subject': 'disease',
+        },
+        {
+          'object': 'literature',
+          'subject': 'disease',
+        },
+        {
+          'object': 'variant',
+          'subject': 'disease',
+        },
+        {
+          'object': 'disease',
+          'subject': 'phenotype',
+        },
+        {
+          'object': 'gene',
+          'subject': 'phenotype',
+        },
+        {
+          'object': 'genotype',
+          'subject': 'phenotype',
+        },
+        {
+          'object': 'literature',
+          'subject': 'phenotype',
+        },
+        {
+          'object': 'variant',
+          'subject': 'phenotype',
+        },
+        {
+          'object': 'gene',
+          'subject': 'goterm',
+        },
+        {
+          'object': 'literature',
+          'subject': 'model',
+        },
+      ];
+      this.inverted = false;
+      invertedCalls.forEach((elem) => {
+        if (this.nodeType === elem.subject && this.cardType === elem.object) {
+          this.inverted = true;
+        }
+      })
+    },
+
+    async fetchData() {
+      const that = this;
+      // console.log('####fetchData');
+      try {
+        const biolinkAnnotationSuffix = this.getBiolinkAnnotation(this.cardType);
+        const params= {
+          fetch_objects: true,
+          start: ((this.currentPage - 1) * this.rowsPerPage),
+          rows: this.rowsPerPage,
+        };
+        let searchResponse = await MA.getNodeAssociations(
+          this.nodeType,
+          this.identifier,
+          biolinkAnnotationSuffix,
+          params
+        );
+        if (!searchResponse.data ||
+            !searchResponse.data.associations) {
+          that.dataPacket = null;
+          throw new Error('MA.getNodeAssociations() returned no data');
+        }
+        that.dataPacket = searchResponse;
+        that.dataFetched = true;
+        that.totalItems = searchResponse.data.numFound;
+        // searchResponse.data.associations.forEach(a => {
+        //   console.log(a.subject.label, a.subject.taxon.label);
+        // });
+        // that.currentPage = 1;
+        that.populateRows();
+      }
+      catch (e) {
+        that.dataError = e;
+        console.log('BioLink Error', e);
+      }
+
+    },
+    populateRows() {
+      this.rows = [];
+      let count = 0;
+      this.dataPacket.data.associations.forEach(elem => {
+        count += 1;
+        let pubs = [
+          'No References',
         ];
-        if (this.taxonFields.includes(this.cardType)) {
-          this.isGene = true;
-          fields.splice(2, 0, {
-            key: 'taxon',
-            label: 'Taxon',
-            sortable: true,
+        let pubsLength = 0;
+        if (elem.publications) {
+          pubs = this.parsePublications(elem.publications);
+          pubsLength += pubs.length;
+        }
+        let evidence = [
+          {
+            lbl: 'No Evidence',
+            id: '',
+          }
+        ];
+        let evidenceLength = 0;
+        const eviResults = this.parseEvidence(elem.evidence_graph.nodes);
+        if (eviResults.length) {
+          evidence = eviResults;
+          evidenceLength += eviResults.length;
+        }
+        let objectElem = elem.object;
+        if (this.inverted) {
+          objectElem = elem.subject;
+        }
+        const taxon = this.parseTaxon(objectElem);
+
+        if (!taxon.id || this.trueFacets.includes(taxon.id)) {
+          this.rows.push({
+            references: pubs,
+            referencesLength: pubsLength,
+            annotationType: this.cardType,
+            evidence: evidence,
+            evidenceLength: evidenceLength,
+            objectCurie: objectElem.id,
+            sources: elem.provided_by,
+            sourcesLength: elem.provided_by.length,
+            assocObject: objectElem.label,
+            objectLink:`/${this.cardType}/${objectElem.id}`,
+            taxonLabel: taxon.label,
+            taxonId: taxon.id,
+            relationId: elem.relation.id,
+            relationLabel: elem.relation.label,
           });
         }
-        this.fields = fields;
-      },
-      getBiolinkAnnotation(val) {
-        let result = `${val}s/`;
-        if (val === 'anatomy') {
-          result = 'expression/anatomy';
-        } else if (val === 'literature') {
-          result = val;
-        } else if (val === 'function') {
-          result = val;
-        }
-        return result;
-      },
-      parseEvidence(evidenceList) {
-        let result = [];
-        if (evidenceList) {
-          result = evidenceList.filter(elem => elem.id.includes('ECO'));
-        }
-        return result;
-      },
-      parsePublications(pubsList) {
-        const pubs = [];
-        pubsList.forEach(elem => pubs.push(elem.id));
-        return pubs;
-      },
-      parseTaxon(elemObj) {
-        const taxon = {
+      });
+    },
+    generateFields() {
+      this.isGene = false;
+      const fields = [
+        {
+          key: 'show_details',
           label: '',
-          id: '',
-        };
-        if ('taxon' in elemObj) {
-          taxon.label = elemObj.taxon.label;
-          taxon.id = elemObj.taxon.id;
-        }
-        return taxon;
-      },
-      firstCap(val) {
-        return val.charAt(0)
-          .toUpperCase() + val.slice(1);
-      },
-    },
-    filters: {
-      pubHref(curie) {
-        const identifier = curie.split(/[:]+/).pop();
-        return `https://www.ncbi.nlm.nih.gov/pubmed/${identifier}`;
-      },
-      eviHref(curie) {
-        const identifier = curie.split(/[:]+/).pop();
-        return `http://purl.obolibrary.org/obo/ECO_${identifier}`;
-      },
-      sourceHref(url) {
-        return url.split(/[/]+/)
-          .pop()
-          .split(/[.]+/)[0]
-          .toUpperCase();
-      },
-    },
-    watch: {
-      cardType() {
-        this.dataFetched = false;
-        this.dataError = false;
-        this.generateFields();
-        this.handleSubjectObjectInversion();
-        this.fetchData();
-      },
-      // dataPacket() {
-      //   if (this.dataPacket) {
-      //     this.populateRows();
-      //   }
-      // },
-      facets: {
-        handler() {
-          this.currentPage = 1;
-          this.fetchData();
         },
-        deep: true,
-      },
+        {
+          key: 'assocObject',
+          label: this.firstCap(this.cardType),
+          'class': 'assoc-column-width ',
+          // sortable: true,
+        },
+        {
+          key: 'evidence',
+          label: 'Evidence',
+        },
+        {
+          key: 'references',
+          label: 'References',
+        },
+        {
+          key: 'sources',
+          label: 'Sources',
+        },
+      ];
+      if (this.taxonFields.includes(this.cardType)) {
+        this.isGene = true;
+        fields.splice(2, 0, {
+          key: 'taxon',
+          label: 'Taxon',
+          // sortable: true,
+        });
+      }
+      this.fields = fields;
     },
-  };
+    getBiolinkAnnotation(val) {
+      let result = `${val}s/`;
+      if (val === 'anatomy') {
+        result = 'expression/anatomy';
+      } else if (val === 'literature') {
+        result = val;
+      } else if (val === 'function') {
+        result = val;
+      }
+      return result;
+    },
+    parseEvidence(evidenceList) {
+      let result = [];
+      if (evidenceList) {
+        result = evidenceList.filter(elem => elem.id.includes('ECO'));
+      }
+      return result;
+    },
+    parsePublications(pubsList) {
+      const pubs = [];
+      pubsList.forEach(elem => pubs.push(elem.id));
+      return pubs;
+    },
+    parseTaxon(elemObj) {
+      const taxon = {
+        label: '',
+        id: '',
+      };
+      if ('taxon' in elemObj) {
+        taxon.label = elemObj.taxon.label;
+        taxon.id = elemObj.taxon.id;
+      }
+      return taxon;
+    },
+    firstCap(val) {
+      return val.charAt(0)
+        .toUpperCase() + val.slice(1);
+    },
+  },
+  filters: {
+    pubHref(curie) {
+      const identifier = curie.split(/[:]+/).pop();
+      return `https://www.ncbi.nlm.nih.gov/pubmed/${identifier}`;
+    },
+    eviHref(curie) {
+      const identifier = curie.split(/[:]+/).pop();
+      return `http://purl.obolibrary.org/obo/ECO_${identifier}`;
+    },
+    sourceHref(url) {
+      return url.split(/[/]+/)
+        .pop()
+        .split(/[.]+/)[0]
+        .toUpperCase();
+    },
+  },
+  watch: {
+    cardType() {
+      this.dataFetched = false;
+      this.dataError = false;
+      this.generateFields();
+      this.handleSubjectObjectInversion();
+
+      this.$refs.tableRef.refresh();
+      // this.fetchData();
+    },
+    // dataPacket() {
+    //   if (this.dataPacket) {
+    //     this.populateRows();
+    //   }
+    // },
+    facets: {
+      handler() {
+        this.currentPage = 1;
+        this.$refs.tableRef.refresh();
+        // this.fetchData();
+      },
+      deep: true,
+    },
+  },
+};
 </script>
 <style scoped>
   a {
@@ -580,8 +593,12 @@
   .assoc-column-width {
     width: 400px;
   }
+
   .list-bullets {
     list-style: square;
+    padding: 0;
+    margin: 0;
+    list-style-position: inside;
   }
 
   a.page-link {
@@ -590,8 +607,17 @@
   .full-width {
     width: 100%;
   }
-  .table thead th{
+  .table thead th {
     border-top: none;
+  }
+
+  .btn-toggle {
+    margin: 0;
+    padding: 0;
+    height: 25px;
+    background: none;
+    border: none;
+    border-left: 2px solid lightgray;
   }
 </style>
 

--- a/ui/components/Home.vue
+++ b/ui/components/Home.vue
@@ -8,23 +8,26 @@
     <div class="intro-body">
       <div class="container">
         <div class="row">
-          <div class="col-md-8 offset-md-2">
-
-            <h1 class="brand-heading">
+          <div class="col-md-12">
+            <div class="brand-heading m-0 p-0">
               <img
                 class="center-block text-center img-fluid"
-                style="max-height:150px;"
+                style="max-height:80px;"
                 src="../assets/images/monarch-logo-white-stacked.png"/>
-            </h1>
-
+            </div>
+          </div>
+          <div
+            class="col-md-12 py-2">
             <p class="intro-text">
               Advancing translational science by semantically integrating biological information across species.
             </p>
+          </div>
+          <div class="col-12">
             <monarch-autocomplete homeSearch="true">
             </monarch-autocomplete>
-
           </div>
         </div>
+
       </div>
     </div>
   </header>
@@ -356,7 +359,8 @@ export default {
     display: table;
     width: 100%;
     height: auto;
-    padding: 50px 0;
+    margin: $navbar-height - 1 0 0 0;
+    padding: 20px 0;
     text-align: center;
     color: white;
     background-color: $monarch-bg-color;
@@ -369,6 +373,7 @@ export default {
         padding: 20px 0 20px 0;
       }
       .intro-text {
+        margin: 5px;
         font-size: 18px;
       }
     }
@@ -376,7 +381,8 @@ export default {
     @media(min-width:$grid-float-breakpoint) {
       .intro-body {
         .intro-text {
-          font-size: 26px;
+          font-size: 22px;
+          line-height: 1.2em;
         }
       }
 

--- a/ui/components/Navbar.vue
+++ b/ui/components/Navbar.vue
@@ -1,7 +1,7 @@
 <template>
 <nav
   id="monarchng-navbar"
-  class="navbar fixed-top navbar-expand-lg navbar-dark bg-dark">
+  class="navbar fixed-top navbar-expand-monarch navbar-dark bg-dark">
 
   <router-link to="/" class="navbar-brand">
     <img class="branding-logo"

--- a/ui/components/Node.vue
+++ b/ui/components/Node.vue
@@ -476,8 +476,8 @@ export default {
       var nonEmptyCards = [];
       this.availableCards.forEach(cardType => {
         const count = that.node[cardType + 'Num'];
-        that.counts[cardType] = count;
-        if (count > 0) {
+        that.counts[cardType] = count ? count.totalCount : 0;
+        if (that.counts[cardType] > 0) {
           nonEmptyCards.push(cardType);
         }
       });
@@ -542,8 +542,7 @@ export default {
 
       try {
         let nodeResponse = await MA.getNodeSummary(this.nodeId, this.nodeType);
-        // console.log('nodeResponse', nodeResponse);
-        // TIP: We got a result, apply it to the Vue model
+
         that.applyResponse(nodeResponse);
         that.clearProgress();
       }

--- a/ui/components/NodeSidebar.vue
+++ b/ui/components/NodeSidebar.vue
@@ -45,7 +45,7 @@
       <li class="list-group-item list-group-item-node">
         <a
           target="_blank"
-          :href="'http://beta.monarchinitiative.org' + $route.path">
+          :href="debugServerName + $route.path">
           <img
             class="entity-type-icon"
             :src="$parent.icons[nodeType]"/>
@@ -136,6 +136,12 @@ export default {
 
   data() {
     return {
+      debugServerName:
+        (
+          (window.serverConfiguration.app_base.length > 0) ?
+            window.serverConfiguration.app_base :
+            'https://beta.monarchinitiative.org'
+        )
     };
   },
 


### PR DESCRIPTION
- Add 'monarch' entry to $grid-breakpoints so navbar collapses a little later than 'md'
- Add api.js fetchAssociationCounts (plural), to retrieve counts and association numbers.
- Style literature pages in way more consistent with other pages.
- Remove recordIndex from AssocTable. Compact the table. Use chevrons for toggle.
- Implement proper paging via BioLink.
- Move list bullets in AssocTable to 'inside' from 'outside' list-style-position
- Adjust Home page so that more of the search is visible without scrolling.
- Add Search Examples to Home Page
- Move Category Filters on Home Page Search closer to search box, to reduce confusion.
- Use 'style lang="scss"' for MonarchAutocomplete.vue.
