### PR TITLE
Add filter for sources for gene to disease tables

### DIFF
--- a/lib/monarch/web/webapp.js
+++ b/lib/monarch/web/webapp.js
@@ -3361,9 +3361,23 @@ function diseaseByIdHandler(request, id, fmt) {
     addGolrTable(info, 'subject_closure', 'phenotypes-table', phenotype_filter, 'disease_phenotype','#phenotypes');
     info.phenotypeNum = engine.fetchAssociationCount(phenotype_filter, 'object');
 
+    const required_sources = [
+        'https://data.monarchinitiative.org/ttl/omim.ttl',
+        'https://data.monarchinitiative.org/ttl/orphanet.ttl',
+        'https://data.monarchinitiative.org/ttl/omia.ttl',
+        'https://data.monarchinitiative.org/ttl/gwascatalog.ttl'
+    ];
+
+    let defined_by_filter = required_sources.reduce((fquery, source) => {
+        return fquery + `"${source}" OR `;
+    }, '(');
+    defined_by_filter = defined_by_filter.slice(0, -4);
+    defined_by_filter += ')';
+
     var gene_filter = [
                        { field: 'subject_category', value: 'gene' },
                        { field: 'object_category', value: 'disease' },
+                       { field: 'is_defined_by', value: defined_by_filter},
                        { field: 'object_closure', value: id }
     ];
     addGolrTable(info, 'object_closure', 'gene-table', gene_filter, 'gene_disease','#genes');
@@ -3664,6 +3678,19 @@ function geneByIdHandler(request, id, fmt) {
         addCoreRenderers(info, 'gene', id);
         addGolrStaticFiles(info);
 
+        const required_sources = [
+            'https://data.monarchinitiative.org/ttl/omim.ttl',
+            'https://data.monarchinitiative.org/ttl/orphanet.ttl',
+            'https://data.monarchinitiative.org/ttl/omia.ttl',
+            'https://data.monarchinitiative.org/ttl/gwascatalog.ttl'
+        ];
+
+        let defined_by_filter = required_sources.reduce((fquery, source) => {
+            return fquery + `"${source}" OR `;
+        }, '(');
+        defined_by_filter = defined_by_filter.slice(0, -4);
+        defined_by_filter += ')';
+
         //Load variables for client side tables
         var phenotype_filter = [
                                 { field: 'object_category', value: 'phenotype' },
@@ -3675,6 +3702,7 @@ function geneByIdHandler(request, id, fmt) {
         var disease_filter = [
                               { field: 'object_category', value: 'disease' },
                               { field: 'subject_category', value: 'gene' },
+                              { field: 'is_defined_by', value: defined_by_filter},
                               { field: 'subject_closure', value: id }
         ];
         addGolrTable(info, 'subject_closure', 'disease-table', disease_filter, 'gene_disease','#diseases');

--- a/lib/monarch/web/webapp.js
+++ b/lib/monarch/web/webapp.js
@@ -3317,7 +3317,20 @@ if (useSPA) {
   web.wrapRouteGet(app, '/node/{nodetype}/{id}.json', ['nodetype', 'id'], nodeByTypeIdHandler, errorResponse);
 }
 
+function getGeneToDiseaseSourceFilter() {
+    const required_sources = [
+        'https://data.monarchinitiative.org/ttl/omim.ttl',
+        'https://data.monarchinitiative.org/ttl/orphanet.ttl',
+        'https://data.monarchinitiative.org/ttl/omia.ttl',
+        'https://data.monarchinitiative.org/ttl/gwascatalog.ttl'
+    ];
 
+    let defined_by_filter = required_sources.reduce((fquery, source) => {
+        return fquery + `"${source}" OR `;
+    }, '(');
+    defined_by_filter = defined_by_filter.slice(0, -4);
+    return defined_by_filter += ')';
+};
 
 function diseaseByIdHandler(request, id, fmt) {
     // engine.log("getting /disease/:id where id="+id + " fmt=" + fmt);
@@ -3361,23 +3374,10 @@ function diseaseByIdHandler(request, id, fmt) {
     addGolrTable(info, 'subject_closure', 'phenotypes-table', phenotype_filter, 'disease_phenotype','#phenotypes');
     info.phenotypeNum = engine.fetchAssociationCount(phenotype_filter, 'object');
 
-    const required_sources = [
-        'https://data.monarchinitiative.org/ttl/omim.ttl',
-        'https://data.monarchinitiative.org/ttl/orphanet.ttl',
-        'https://data.monarchinitiative.org/ttl/omia.ttl',
-        'https://data.monarchinitiative.org/ttl/gwascatalog.ttl'
-    ];
-
-    let defined_by_filter = required_sources.reduce((fquery, source) => {
-        return fquery + `"${source}" OR `;
-    }, '(');
-    defined_by_filter = defined_by_filter.slice(0, -4);
-    defined_by_filter += ')';
-
     var gene_filter = [
                        { field: 'subject_category', value: 'gene' },
                        { field: 'object_category', value: 'disease' },
-                       { field: 'is_defined_by', value: defined_by_filter},
+                       { field: 'is_defined_by', value: getGeneToDiseaseSourceFilter()},
                        { field: 'object_closure', value: id }
     ];
     addGolrTable(info, 'object_closure', 'gene-table', gene_filter, 'gene_disease','#genes');
@@ -3678,19 +3678,6 @@ function geneByIdHandler(request, id, fmt) {
         addCoreRenderers(info, 'gene', id);
         addGolrStaticFiles(info);
 
-        const required_sources = [
-            'https://data.monarchinitiative.org/ttl/omim.ttl',
-            'https://data.monarchinitiative.org/ttl/orphanet.ttl',
-            'https://data.monarchinitiative.org/ttl/omia.ttl',
-            'https://data.monarchinitiative.org/ttl/gwascatalog.ttl'
-        ];
-
-        let defined_by_filter = required_sources.reduce((fquery, source) => {
-            return fquery + `"${source}" OR `;
-        }, '(');
-        defined_by_filter = defined_by_filter.slice(0, -4);
-        defined_by_filter += ')';
-
         //Load variables for client side tables
         var phenotype_filter = [
                                 { field: 'object_category', value: 'phenotype' },
@@ -3702,7 +3689,7 @@ function geneByIdHandler(request, id, fmt) {
         var disease_filter = [
                               { field: 'object_category', value: 'disease' },
                               { field: 'subject_category', value: 'gene' },
-                              { field: 'is_defined_by', value: defined_by_filter},
+                              { field: 'is_defined_by', value: getGeneToDiseaseSourceFilter()},
                               { field: 'subject_closure', value: id }
         ];
         addGolrTable(info, 'subject_closure', 'disease-table', disease_filter, 'gene_disease','#diseases');


### PR DESCRIPTION
This PR adds a filter on gene to disease views that requires at least one of a set of sources, currently omim, orphanet, gwascatalog, omia.  This will remove gene to disease associations where either ctd, clinvar, or coriell are the only sources.  See as a background:

https://github.com/monarch-initiative/monarch-app/issues/1591
https://github.com/monarch-initiative/dipper/issues/593
https://github.com/monarch-initiative/monarch-cypher-queries/issues/23
https://github.com/monarch-initiative/dipper/pull/602
https://github.com/monarch-initiative/dipper/issues/685